### PR TITLE
fix: print empty string not "None"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.1"
+version = "0.1.1"
 authors = [{ name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" }]
 description = "A github runner image builder package"
 readme = "README.md"

--- a/src/github_runner_image_builder/store.py
+++ b/src/github_runner_image_builder/store.py
@@ -78,7 +78,7 @@ def _prune_old_images(
             raise OpenstackError from exc
 
 
-def get_latest_build_id(cloud_name: str, image_name: str) -> str | None:
+def get_latest_build_id(cloud_name: str, image_name: str) -> str:
     """Fetch the latest image id.
 
     Args:
@@ -91,7 +91,7 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> str | None:
     with openstack.connect(cloud=cloud_name) as connection:
         images = _get_sorted_images_by_created_at(connection=connection, image_name=image_name)
         if not images:
-            return None
+            return ""
         return images[0].id
 
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -161,7 +161,7 @@ def test_upload_image(mock_connection: MagicMock):
 @pytest.mark.parametrize(
     "images, expected_id",
     [
-        pytest.param([], None, id="No images"),
+        pytest.param([], "", id="No images"),
         pytest.param(
             [
                 MockOpenstackImageFactory(id="1", created_at="2024-01-01T00:00:00Z"),


### PR DESCRIPTION
Applicable spec: N/A

### Overview

When None is returned, the print statement prints "None", making the charm think it is a sane value.

### Rationale

Fixes a bug where relation data "None" is sent over to Github runner.

### Module Changes

None.

### Library/Dependency Changes

None

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
