### PR TITLE
feat: embed github runner

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -47,3 +47,6 @@ jobs:
       # need to run in sudo mode due to chroot
       - name: Run integration tests
         run: sudo $(which tox) -e integration -- -m amd64 --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: canonical/action-tmate@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,7 +25,7 @@ jobs:
           pipx install tox
       # need to run in sudo mode due to chroot
       - name: Run integration tests
-        run: sudo $(which tox) -e integration -- -m arm64 --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+        run: tox -e integration -- -m arm64 --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Tmate
         if: ${{ failure() }}
         uses: canonical/action-tmate@main
@@ -46,7 +46,7 @@ jobs:
           pipx install tox
       # need to run in sudo mode due to chroot
       - name: Run integration tests
-        run: sudo $(which tox) -e integration -- -m amd64 --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS }}
+        run: tox -e integration -- -m amd64 --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS }}
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: canonical/action-tmate@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -47,6 +47,3 @@ jobs:
       # need to run in sudo mode due to chroot
       - name: Run integration tests
         run: tox -e integration -- -m amd64 --image=${{ matrix.image }} ${{ secrets.INTEGRATION_TEST_ARGS }}
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: canonical/action-tmate@main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,3 +9,5 @@ jobs:
     secrets: inherit
     with:
       self-hosted-runner: true
+      tmate-debug: true
+      tmate-timeout: 60

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,5 +9,3 @@ jobs:
     secrets: inherit
     with:
       self-hosted-runner: true
-      tmate-debug: true
-      tmate-timeout: 60

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -216,10 +216,15 @@ def build_image(arch: Arch, base_image: BaseImage) -> None:
                 env=APT_NONINTERACTIVE_ENV,
             )
             logger.info("apt-get install out: %s", output)
+            logger.info("Disabling unattended upgrades.")
             _disable_unattended_upgrades()
+            logger.info("Configuring system users.")
             _configure_system_users()
+            logger.info("Configuring /usr/local/bin directory.")
             _configure_usr_local_bin()
+            logger.info("Installing Yarn.")
             _install_yarn()
+            logger.info("Installing GitHub runner.")
             _install_github_runner()
     except ChrootBaseError as exc:
         raise BuildImageError from exc

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -781,7 +781,7 @@ def _install_github_runner() -> None:
         )
     except urllib.error.URLError as exc:
         raise RunnerDownloadError("Error downloading runner tar archive.") from exc
-    ACTIONS_RUNNER_PATH.mkdir(exist_ok=True)
+    ACTIONS_RUNNER_PATH.mkdir(parents=True, exist_ok=True)
     try:
         with contextlib.closing(
             tarfile.open(name=None, fileobj=BytesIO(tar_res.read()))

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -14,6 +14,8 @@ import hashlib
 import http
 import http.client
 import logging
+import os
+import pwd
 import shutil
 
 # Ignore B404:blacklist since all subprocesses are run with predefined executables.
@@ -802,6 +804,8 @@ def _install_github_runner(arch: Arch) -> None:
             tar_file.extractall(path=ACTIONS_RUNNER_PATH)  # nosec: B202
     except tarfile.TarError as exc:
         raise RunnerDownloadError("Error extracting runner tar archive.") from exc
+    ubuntu_user = pwd.getpwnam(UBUNTU_USER)
+    os.chown(ACTIONS_RUNNER_PATH, uid=ubuntu_user.pw_uid, gid=ubuntu_user.pw_gid)
 
 
 # Image compression might fail for arbitrary reasons - retrying usually solves this.

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -777,7 +777,7 @@ def _install_github_runner() -> None:
     try:
         tar_res = urllib.request.urlopen(
             f"https://github.com/actions/runner/releases/download/{latest_version}/"
-            f"actions-runner-linux-x64-${version_number}.tar.gz"
+            f"actions-runner-linux-x64-{version_number}.tar.gz"
         )
     except urllib.error.URLError as exc:
         raise RunnerDownloadError("Error downloading runner tar archive.") from exc

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -234,7 +234,7 @@ def build_image(arch: Arch, base_image: BaseImage) -> None:
             logger.info("Installing Yarn.")
             _install_yarn()
             logger.info("Installing GitHub runner.")
-            _install_github_runner()
+            _install_github_runner(arch=arch)
     except ChrootBaseError as exc:
         raise BuildImageError from exc
 
@@ -761,8 +761,11 @@ def _install_yarn() -> None:
         raise YarnInstallError from exc
 
 
-def _install_github_runner() -> None:
+def _install_github_runner(arch: Arch) -> None:
     """Download and install github runner.
+
+    Args:
+        arch: The architecture of the host image.
 
     Raises:
         RunnerDownloadError: If there was an error downloading runner.
@@ -787,7 +790,7 @@ def _install_github_runner() -> None:
         # The github releases URL is safe to open
         with urllib.request.urlopen(  # nosec: B310
             f"https://github.com/actions/runner/releases/download/{latest_version}/"
-            f"actions-runner-linux-x64-{version_number}.tar.gz"
+            f"actions-runner-linux-{arch.value}-{version_number}.tar.gz"
         ) as tar_res:
             tar_bytes = tar_res.read()
     except urllib.error.URLError as exc:

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -621,10 +621,6 @@ def _disable_unattended_upgrades() -> None:
         # use subprocess run rather than operator-libs-linux's systemd library since the library
         # does not provide full features like mask.
         output = subprocess.check_output(
-            ["/usr/bin/systemctl", "stop", APT_TIMER], timeout=30
-        )  # nosec: B603
-        logger.info("systemctl stop apt timer out: %s", output)
-        output = subprocess.check_output(
             ["/usr/bin/systemctl", "disable", APT_TIMER], timeout=30
         )  # nosec: B603
         logger.info("systemctl disable apt timer out: %s", output)
@@ -632,10 +628,6 @@ def _disable_unattended_upgrades() -> None:
             ["/usr/bin/systemctl", "mask", APT_SVC], timeout=30
         )  # nosec: B603
         logger.info("systemctl mask apt timer out: %s", output)
-        output = subprocess.check_output(
-            ["/usr/bin/systemctl", "stop", APT_UPGRADE_TIMER], timeout=30
-        )  # nosec: B603
-        logger.info("systemctl stop apt upgrade timer out: %s", output)
         output = subprocess.check_output(  # nosec: B603
             ["/usr/bin/systemctl", "disable", APT_UPGRADE_TIMER], timeout=30
         )
@@ -644,10 +636,6 @@ def _disable_unattended_upgrades() -> None:
             ["/usr/bin/systemctl", "mask", APT_UPGRAD_SVC], timeout=30
         )  # nosec: B603
         logger.info("systemctl mask apt upgrade timer out: %s", output)
-        output = subprocess.check_output(
-            ["/usr/bin/systemctl", "daemon-reload"], timeout=30
-        )  # nosec: B603
-        logger.info("systemctl daemon-reload out: %s", output)
         output = subprocess.check_output(  # nosec: B603
             ["/usr/bin/apt-get", "remove", "-y", "unattended-upgrades"],
             env=APT_NONINTERACTIVE_ENV,

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -809,8 +809,8 @@ def _install_github_runner(arch: Arch) -> None:
             [
                 "/usr/bin/chown",
                 "-R",
-                str(ACTIONS_RUNNER_PATH),
                 f"{ubuntu_user.pw_uid}:{ubuntu_user.pw_gid}",
+                str(ACTIONS_RUNNER_PATH),
             ],
             timeout=60,
         )

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -80,7 +80,7 @@ DOCKER_GROUP = "docker"
 MICROK8S_GROUP = "microk8s"
 LXD_GROUP = "lxd"
 UBUNTU_HOME = Path("/home/ubuntu")
-ACTIONS_RUNNER_PATH = IMAGE_MOUNT_DIR / "home" / UBUNTU_USER / "actions-runner"
+ACTIONS_RUNNER_PATH = UBUNTU_HOME / "actions-runner"
 
 # Constants for packages in the image
 YQ_REPOSITORY_URL = "https://github.com/mikefarah/yq.git"

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -43,6 +43,8 @@ from github_runner_image_builder.errors import (
 )
 from github_runner_image_builder.utils import retry
 
+logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger(__name__)
 
 SupportedBaseImageArch = Literal["amd64", "arm64"]

--- a/src/github_runner_image_builder/errors.py
+++ b/src/github_runner_image_builder/errors.py
@@ -69,6 +69,10 @@ class YarnInstallError(BuildImageError):
     """Represents an error installilng Yarn."""
 
 
+class RunnerDownloadError(BuildImageError):
+    """Represents an error downloading GitHub runner tar archive."""
+
+
 class ImageCompressError(BuildImageError):
     """Represents an error while compressing cloud-img."""
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@
 import logging
 import secrets
 import string
+import subprocess
 import typing
 from pathlib import Path
 
@@ -20,7 +21,6 @@ from openstack.connection import Connection
 from openstack.image.v2.image import Image
 from openstack.network.v2.security_group import SecurityGroup
 
-from github_runner_image_builder.cli import main
 from tests.integration import helpers, types
 
 logger = logging.getLogger(__name__)
@@ -306,10 +306,16 @@ def cli_run_fixture(
     openstack_connection: Connection,
     openstack_image_name: str,
 ):
-    """A CLI run."""
-    main(["init"])
-    main(
+    """A CLI run.
+
+    This fixture assumes pipx is installed in the system and the github-runner-image-builder has
+    been installed using pipx. See testenv:integration section of tox.ini.
+    """
+    subprocess.check_call(["sudo", Path.home() / ".local/bin/github-runner-image-builder", "init"])
+    subprocess.check_call(
         [
+            "sudo",
+            Path.home() / ".local/bin/github-runner-image-builder",
             "run",
             cloud_name,
             openstack_image_name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,9 @@
 import logging
 import secrets
 import string
-import subprocess
+
+# Subprocess is used to run the application.
+import subprocess  # nosec: B404
 import typing
 from pathlib import Path
 
@@ -311,10 +313,13 @@ def cli_run_fixture(
     This fixture assumes pipx is installed in the system and the github-runner-image-builder has
     been installed using pipx. See testenv:integration section of tox.ini.
     """
-    subprocess.check_call(["sudo", Path.home() / ".local/bin/github-runner-image-builder", "init"])
-    subprocess.check_call(
+    # This is a locally built application - we can trust it.
+    subprocess.check_call(  # nosec: B603
+        ["/usr/bin/sudo", Path.home() / ".local/bin/github-runner-image-builder", "init"]
+    )
+    subprocess.check_call(  # nosec: B603
         [
-            "sudo",
+            "/usr/bin/sudo",
             Path.home() / ".local/bin/github-runner-image-builder",
             "run",
             cloud_name,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -19,7 +19,7 @@ from fabric import Result
 from invoke.exceptions import UnexpectedExit
 from openstack.compute.v2.server import Server
 from openstack.connection import Connection
-from paramiko.ssh_exception import NoValidConnectionsError
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 from pylxd import Client
 from pylxd.models.image import Image
 from pylxd.models.instance import Instance, InstanceState
@@ -266,7 +266,7 @@ async def wait_for_valid_connection(  # pylint: disable=too-many-arguments
                 if result.ok:
                     await _install_proxy(conn=ssh_connection, proxy=proxy)
                     return ssh_connection
-            except (NoValidConnectionsError, TimeoutError) as exc:
+            except (NoValidConnectionsError, TimeoutError, SSHException) as exc:
                 logger.warning("Connection not yet ready, %s.", str(exc))
         time.sleep(10)
     raise TimeoutError("No valid ssh connections found.")

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -35,3 +35,14 @@ class MockOpenstackImageFactory(factory.Factory):
 
     id: str  # UUID
     created_at = Faker("date")  # Example format: 2024-04-16T04:31:12Z
+
+
+class MockRequestsReponseFactory(factory.Factory):
+    """Mock requests response."""  # noqa: DCO060
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Configuration for factory."""  # noqa: DCO060
+
+        model = MagicMock
+
+    is_redirect: bool

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -800,6 +800,12 @@ def test__install_yarn(monkeypatch: pytest.MonkeyPatch):
             MagicMock(side_effect=builder.tarfile.TarError),
             "Error extracting runner tar archive.",
         ),
+        pytest.param(
+            builder.subprocess,
+            "check_call",
+            MagicMock(side_effect=subprocess.SubprocessError()),
+            "Error changing github runner directory.",
+        ),
     ],
 )
 def test__install_github_runner_error(
@@ -816,7 +822,7 @@ def test__install_github_runner_error(
     monkeypatch.setattr(builder, "ACTIONS_RUNNER_PATH", MagicMock())
     monkeypatch.setattr(builder, "BytesIO", MagicMock())
     monkeypatch.setattr(builder.pwd, "getpwnam", MagicMock())
-    monkeypatch.setattr(builder.os, "chown", MagicMock())
+    monkeypatch.setattr(builder.subprocess, "check_call", MagicMock())
     monkeypatch.setattr(module, func, mock)
 
     with pytest.raises(builder.RunnerDownloadError) as exc:
@@ -837,7 +843,7 @@ def test__install_github_runner(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(builder, "ACTIONS_RUNNER_PATH", MagicMock())
     monkeypatch.setattr(builder, "BytesIO", MagicMock())
     monkeypatch.setattr(builder.pwd, "getpwnam", MagicMock())
-    monkeypatch.setattr(builder.os, "chown", MagicMock())
+    monkeypatch.setattr(builder.subprocess, "check_call", MagicMock())
 
     builder._install_github_runner(arch=Arch.ARM64)
 

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -815,6 +815,8 @@ def test__install_github_runner_error(
     monkeypatch.setattr(builder.tarfile, "open", MagicMock())
     monkeypatch.setattr(builder, "ACTIONS_RUNNER_PATH", MagicMock())
     monkeypatch.setattr(builder, "BytesIO", MagicMock())
+    monkeypatch.setattr(builder.pwd, "getpwnam", MagicMock())
+    monkeypatch.setattr(builder.os, "chown", MagicMock())
     monkeypatch.setattr(module, func, mock)
 
     with pytest.raises(builder.RunnerDownloadError) as exc:
@@ -834,6 +836,8 @@ def test__install_github_runner(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(builder.tarfile, "open", MagicMock())
     monkeypatch.setattr(builder, "ACTIONS_RUNNER_PATH", MagicMock())
     monkeypatch.setattr(builder, "BytesIO", MagicMock())
+    monkeypatch.setattr(builder.pwd, "getpwnam", MagicMock())
+    monkeypatch.setattr(builder.os, "chown", MagicMock())
 
     builder._install_github_runner(arch=Arch.ARM64)
 

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -818,7 +818,7 @@ def test__install_github_runner_error(
     monkeypatch.setattr(module, func, mock)
 
     with pytest.raises(builder.RunnerDownloadError) as exc:
-        builder._install_github_runner()
+        builder._install_github_runner(arch=Arch.X64)
 
     assert expected_message in str(exc.getrepr())
 
@@ -835,7 +835,7 @@ def test__install_github_runner(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(builder, "ACTIONS_RUNNER_PATH", MagicMock())
     monkeypatch.setattr(builder, "BytesIO", MagicMock())
 
-    builder._install_github_runner()
+    builder._install_github_runner(arch=Arch.ARM64)
 
 
 def test__disconnect_image_to_network_block_device_fail(monkeypatch: pytest.MonkeyPatch):

--- a/tox.ini
+++ b/tox.ini
@@ -100,12 +100,14 @@ commands =
 
 [testenv:integration]
 description = Run integration tests
+allowlist_externals=pipx
 deps =
     pytest
     pytest-asyncio
     -r{toxinidir}/requirements.txt
     -r{[vars]tst_path}integration/requirements.txt
 commands =
+    pipx install .
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
 
 [testenv:src-docs]


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Embed GitHub runner to the image.

### Rationale

GitHub runners can be downloaded without GitHub tokens.
For faster image boot.

### Module Changes

- `builder.py`: includes GitHub runner download.

### Library/Dependency Changes

None.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
