### PR TITLE
fix: add apt packages (missing gcc issue on integration tests)

### DIFF
--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -98,6 +98,7 @@ YQ_REPOSITORY_PATH = Path("yq_source")
 HOST_YQ_BIN_PATH = Path("/usr/bin/yq")
 MOUNTED_YQ_BIN_PATH = IMAGE_MOUNT_DIR / "usr/bin/yq"
 IMAGE_DEFAULT_APT_PACKAGES = [
+    "build-essential",
     "docker.io",
     "gh",
     "jq",
@@ -105,6 +106,8 @@ IMAGE_DEFAULT_APT_PACKAGES = [
     "python3-pip",
     "python-is-python3",
     "shellcheck",
+    "tar",
+    "time",
     "unzip",
     "wget",
 ]

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -103,6 +103,7 @@ IMAGE_DEFAULT_APT_PACKAGES = [
     "gh",
     "jq",
     "npm",
+    "python3-dev",
     "python3-pip",
     "python-is-python3",
     "shellcheck",


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The `x86_64-linux-gnu-gcc` lib is missing and is [failing integration test w/ pylibjuju](https://github.com/canonical/github-runner-operator/actions/runs/9935413149/job/27441714422?pr=321).
The package is missing because we are doing `apt install` with `--no-recommends ` flag, hence this does not become a dependency to other packages.

There are quite a few package diffs on GitHub hosted runner and our self-hosted runners.
List of top level manually installed apt packages on GitHub hosted runners: https://pastebin.canonical.com/p/dzXYKcV9dC/
List of top level manually installed apt packages on self hosted runners: https://pastebin.canonical.com/p/n7c72mYXnb/

### Rationale

<!-- The reason the change is needed -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
