### PR TITLE
fix: pull before deleting tags

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - name: Remove git edge stable
         run: |
+          git pull
           git tag -d stable && git push origin :refs/tags/stable
       - name: Apply new stable tag
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - name: Remove git edge tag
         run: |
+          git pull
           git tag -d edge && git push origin :refs/tags/edge
       - name: Apply new edge tag
         run: |


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds a git pull step before modifying tags. 

### Rationale

Checkout action only checks out the ref of the commit that triggered the workflow. The tags are hence missing when trying to delete.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
