### PR TITLE
feat: swap out to click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml==6.0.1
 openstacksdk==3.1.0
+click==8.1.7

--- a/src/github_runner_image_builder/__main__.py
+++ b/src/github_runner_image_builder/__main__.py
@@ -1,9 +1,0 @@
-# Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-"""Main entrypoint for github-runner-image-builder."""
-
-from github_runner_image_builder.cli import main
-
-if __name__ == "__main__":
-    main()

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -2,238 +2,116 @@
 # See LICENSE file for licensing details.
 
 """Main entrypoint for github-runner-image-builder cli application."""
-import argparse
-import dataclasses
-import itertools
-
 # Subprocess module is used to execute trusted commands
 import subprocess  # nosec: B404
 from pathlib import Path
-from typing import cast
+
+import click
 
 from github_runner_image_builder import builder, store
 from github_runner_image_builder.config import (
-    ACTION_INIT,
-    ACTION_LATEST_BUILD_ID,
-    ACTION_RUN,
+    BASE_CHOICES,
     IMAGE_OUTPUT_PATH,
-    LTS_IMAGE_VERSION_TAG_MAP,
-    ActionsNamespace,
     BaseImage,
     get_supported_arch,
 )
 
 
-def main(args: list[str] | None = None) -> None:
-    """Run entrypoint for Github runner image builder CLI.
+@click.group()
+def main() -> None:
+    """Run entrypoint for Github runner image builder CLI."""
+
+
+@main.command(name="init")
+def initialize() -> None:
+    """Initialize builder CLI function wrapper."""
+    builder.initialize()
+
+
+@main.command(name="latest-build-id")
+@click.argument("cloud_name")
+@click.argument("image_name")
+def get_latest_build_id(cloud_name: str, image_name: str) -> None:
+    # Click arguments do not take help parameter, display help through docstrings.
+    """Get latest build ID of <image_name> from Openstack <cloud_name>.
 
     Args:
-        args: Command line arguments.
-
-    Raises:
-        ValueError: If invalid action argument was supplied.
+        cloud_name: The cloud to use from the clouds.yaml file. The CLI looks for clouds.yaml in
+            paths of the following order: current directory, ~/.config/openstack, /etc/openstack.
+        image_name: The image name uploaded to Openstack.
     """
-    options = _parse_args(args)
-    if options.action == "init":
-        builder.initialize()
-        return
-    if options.action == "latest-build-id":
-        print(
-            store.get_latest_build_id(
-                cloud_name=options.cloud_name, image_name=options.image_name
-            ),
-            end="",
-        )
-        return
-    if options.action == "run":
-        _build_and_upload(
-            base=options.base,
-            openstack_config=OpenStackConfig(
-                cloud_name=options.cloud_name,
-                image_name=options.image_name,
-                keep_revisions=options.keep_revisions,
-            ),
-            runner_version=options.runner_version,
-            callback_script_path=options.callback_script_path,
-        )
-        return
-    raise ValueError("Invalid CLI action argument.")
-
-
-def _parse_args(args: list[str] | None = None) -> ActionsNamespace:
-    """Parse CLI arguments.
-
-    Args:
-        args: Command line arguments.
-
-    Returns:
-        An object with parsed user inputs.
-    """
-    parser = argparse.ArgumentParser(
-        prog="Github runner image builder CLI",
-        description="Builds github runner image and uploads it to openstack.",
+    click.echo(
+        message=store.get_latest_build_id(cloud_name=cloud_name, image_name=image_name),
+        nl=False,
     )
-    subparsers = parser.add_subparsers(
-        title="actions",
-        description="command modes for Github runner image builder CLI.",
-        dest="action",
-        required=True,
-    )
-    subparsers.add_parser(ACTION_INIT)
-    get_latest_id_parser = subparsers.add_parser(
-        ACTION_LATEST_BUILD_ID, description="Fetch the latest ID of the built image."
-    )
-    run_parser = subparsers.add_parser(ACTION_RUN, description="Build the image.")
-    get_latest_id_parser.add_argument(
-        dest="cloud_name",
-        help=(
-            "The cloud to use from the clouds.yaml file. The CLI looks for clouds.yaml in paths "
-            "of the following order: current directory, ~/.config/openstack, /etc/openstack."
-        ),
-        type=_non_empty_string,
-    )
-    get_latest_id_parser.add_argument(
-        dest="image_name",
-        help="The image name uploaded to Openstack.",
-        type=_non_empty_string,
-    )
-    run_parser.add_argument(
-        dest="cloud_name",
-        help=(
-            "The cloud to use from the clouds.yaml file. The CLI looks for clouds.yaml in paths "
-            "of the following order: current directory, ~/.config/openstack, /etc/openstack."
-        ),
-        type=_non_empty_string,
-    )
-    run_parser.add_argument(
-        dest="image_name",
-        help="The image name to upload to Openstack.",
-        type=_non_empty_string,
-    )
-    run_parser.add_argument(
-        "-b",
-        "--base-image",
-        dest="base",
-        required=False,
-        choices=tuple(
-            itertools.chain.from_iterable(
-                (tag, name) for (tag, name) in LTS_IMAGE_VERSION_TAG_MAP.items()
-            )
-        ),
-        default="noble",
-    )
-    run_parser.add_argument(
-        "-k",
-        "--keep-revisions",
-        dest="keep_revisions",
-        required=False,
-        type=int,
-        default=5,
-        help="The maximum number of images to keep before deletion.",
-    )
-    run_parser.add_argument(
-        "-s",
-        "--callback-script",
-        dest="callback_script_path",
-        required=False,
-        type=_existing_path,
-        help=(
-            "The callback script to trigger after image is built. The callback script is called"
-            "with the first argument as the image ID."
-        ),
-    )
-    run_parser.add_argument(
-        "-r",
-        "--runner-version",
-        dest="runner_version",
-        required=False,
-        type=str,
-        help=(
-            "The GitHub runner version to install, e.g. 2.317.0. "
-            "See github.com/actions/runner/releases/."
-            "Defaults to latest version."
-        ),
-        default="",
-    )
-    options = cast(ActionsNamespace, parser.parse_args(args))
-    return options
 
 
-def _existing_path(value: str) -> Path:
-    """Check the path exists.
-
-    Args:
-        value: The path string.
-
-    Raises:
-        ValueError: If the path does not exist.
-
-    Returns:
-        Path that exists.
-    """
-    path = Path(value)
-    if not path.exists():
-        raise ValueError(f"Given path {value} not found.")
-    return path
-
-
-def _non_empty_string(arg: str) -> str:
-    """Check that the argument is non-empty.
-
-    Args:
-        arg: The argument to check.
-
-    Raises:
-        ValueError: If the argument is empty.
-
-    Returns:
-        Non-empty string.
-    """
-    arg = str(arg)
-    if not arg:
-        raise ValueError("Must not be empty string")
-    return arg
-
-
-@dataclasses.dataclass
-class OpenStackConfig:
-    """The OpenStack image configuration values.
-
-    Attributes:
-        cloud_name: The Openstack cloud to upload the image to.
-        image_name: The image name to upload as.
-        keep_revisions: Number of image revisions to keep before deletion.
-    """
-
-    cloud_name: str
-    image_name: str
-    keep_revisions: int
-
-
-def _build_and_upload(
-    base: str,
-    openstack_config: OpenStackConfig,
+@main.command(name="run")
+@click.argument("cloud_name")
+@click.argument("image_name")
+@click.option(
+    "-b",
+    "--base-image",
+    type=click.Choice(BASE_CHOICES),
+    default="noble",
+    help=("The Ubuntu base image to use as build base."),
+)
+@click.option(
+    "-k",
+    "--keep-revisions",
+    default=5,
+    help="The maximum number of images to keep before deletion.",
+)
+@click.option(
+    "-s",
+    "--callback-script",
+    type=click.Path(exists=True),
+    default=None,
+    help=(
+        "The callback script to trigger after image is built. The callback script is called"
+        "with the first argument as the image ID."
+    ),
+)
+@click.option(
+    "-r",
+    "--runner-version",
+    default="",
+    help=(
+        "The GitHub runner version to install, e.g. 2.317.0. "
+        "See github.com/actions/runner/releases/."
+        "Defaults to latest version."
+    ),
+)
+# click doesn't yet support dataclasses, hence all arguments are required.
+def run(  # pylint: disable=too-many-arguments
+    cloud_name: str,
+    image_name: str,
+    base_image: str,
+    keep_revisions: int,
+    callback_script: Path | None,
     runner_version: str,
-    callback_script_path: Path | None = None,
 ) -> None:
-    """Build and upload image.
+    """Run build function wrapper.
 
     Args:
-        base: Ubuntu image base.
-        openstack_config: The OpenStack configuration values for uploading image.
-        callback_script_path: Path to bash script to call after image upload.
-        runner_version: The GitHub runner version to download.
+        cloud_name: The cloud to use from the clouds.yaml file. The CLI looks for clouds.yaml in
+            paths of the following order: current directory, ~/.config/openstack, /etc/openstack.
+        image_name: The image name uploaded to Openstack.
+        base_image: The Ubuntu base image to use as build base.
+        keep_revisions: Number of past revisions to keep before deletion.
+        callback_script: Script to callback after a successful build.
+        runner_version: GitHub runner version to pin.
     """
     arch = get_supported_arch()
-    base_image = BaseImage.from_str(base)
-    builder.build_image(arch=arch, base_image=base_image, runner_version=runner_version)
+    base = BaseImage.from_str(base_image)
+    builder.build_image(arch=arch, base_image=base, runner_version=runner_version)
     image_id = store.upload_image(
         arch=arch,
-        cloud_name=openstack_config.cloud_name,
-        image_name=openstack_config.image_name,
+        cloud_name=cloud_name,
+        image_name=image_name,
         image_path=IMAGE_OUTPUT_PATH,
-        keep_revisions=openstack_config.keep_revisions,
+        keep_revisions=keep_revisions,
     )
-    if callback_script_path:
+    if callback_script:
         # The callback script is a user trusted script.
-        subprocess.check_call([str(callback_script_path), image_id])  # nosec: B603
+        subprocess.check_call([str(callback_script), image_id])  # nosec: B603

--- a/src/github_runner_image_builder/config.py
+++ b/src/github_runner_image_builder/config.py
@@ -3,44 +3,13 @@
 
 """Module containing configurations."""
 
-import argparse
-import logging
+import itertools
 import platform
 from enum import Enum
 from pathlib import Path
 from typing import Literal
 
 from github_runner_image_builder.errors import UnsupportedArchitectureError
-
-logger = logging.getLogger(__name__)
-
-ACTION_INIT = "init"
-ACTION_RUN = "run"
-ACTION_LATEST_BUILD_ID = "latest-build-id"
-
-
-# This is a class used for type hinting argparse.
-class ActionsNamespace(argparse.Namespace):  # pylint: disable=too-few-public-methods
-    """Action positional argument namespace.
-
-    Attributes:
-        action: CLI action positional argument.
-        base: The base image to build.
-        callback_script_path: The callback script path to run after image build.
-        cloud_name: The Openstack cloud to interact with. The CLI assumes clouds.yaml is written
-            to the default path, i.e. current directory or ~/.config/openstack or /etc/openstack.
-        image_name: The image name to upload as.
-        keep_revisions: The maximum number of images to keep before deletion.
-        runner_version: The GitHub runner version. See https://github.com/actions/runner/releases/.
-    """
-
-    action: Literal["init", "run", "latest-build-id"]
-    base: Literal["22.04", "jammy", "24.04", "noble"]
-    callback_script_path: Path | None
-    cloud_name: str
-    image_name: str
-    keep_revisions: int
-    runner_version: str
 
 
 class Arch(str, Enum):
@@ -134,5 +103,7 @@ class BaseImage(str, Enum):
 
 
 LTS_IMAGE_VERSION_TAG_MAP = {"22.04": BaseImage.JAMMY.value, "24.04": BaseImage.NOBLE.value}
-
+BASE_CHOICES = tuple(
+    itertools.chain.from_iterable((tag, name) for (tag, name) in LTS_IMAGE_VERSION_TAG_MAP.items())
+)
 IMAGE_OUTPUT_PATH = Path("compressed.img")

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -13,7 +13,7 @@ from fabric.runners import Result
 from openstack.connection import Connection
 from pylxd import Client
 
-from github_runner_image_builder.cli import main
+from github_runner_image_builder.cli import get_latest_build_id
 from github_runner_image_builder.config import IMAGE_OUTPUT_PATH
 from tests.integration.helpers import (
     create_lxd_instance,
@@ -185,7 +185,7 @@ async def test_get_image(
     act: when get image id is run.
     assert: the latest image matches the stdout output.
     """
-    main(["latest-build-id", cloud_name, openstack_image_name])
+    get_latest_build_id(cloud_name, openstack_image_name)
     image_id = openstack_connection.get_image_id(openstack_image_name)
 
     res = capsys.readouterr()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Swap out Python's argparse with click.
<!-- A high level overview of the change -->

### Rationale

- Easier CLI management for extending features.
<!-- The reason the change is needed -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
- cli.py
- pyproject.toml to invoke CLI main.

### Library/Dependency Changes

<!-- Any changes to libraries -->
- Added click lib

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
