### PR TITLE
fix: add users to sudoers group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -84,6 +84,7 @@ UBUNTU_USER = "ubuntu"
 DOCKER_GROUP = "docker"
 MICROK8S_GROUP = "microk8s"
 LXD_GROUP = "lxd"
+SUDOERS_GROUP = "sudo"
 UBUNTU_HOME = Path("/home/ubuntu")
 ACTIONS_RUNNER_PATH = UBUNTU_HOME / "actions-runner"
 
@@ -569,7 +570,7 @@ def _configure_system_users() -> None:
             [
                 "/usr/sbin/usermod",
                 "-aG",
-                f"{DOCKER_GROUP},{MICROK8S_GROUP},{LXD_GROUP}",
+                f"{DOCKER_GROUP},{MICROK8S_GROUP},{LXD_GROUP},{SUDOERS_GROUP}",
                 UBUNTU_USER,
             ],
             timeout=30,

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -54,7 +54,7 @@ function configure_system_users() {
     echo "PATH=\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.profile
     echo "PATH=\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.bashrc
     /usr/sbin/groupadd microk8s
-    /usr/sbin/usermod --append --groups docker,microk8s,lxd ubuntu
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
 }
 
 function configure_usr_local_bin() {

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -24,7 +24,7 @@ class Commands:
 # This is matched with E2E test run of github-runner-operator charm.
 TEST_RUNNER_COMMANDS = (
     Commands(name="simple hello world", command="echo hello world"),
-    Commands(name="print groups", command="groups"),
+    Commands(name="print groups", command="groups | grep sudo"),
     Commands(name="file permission to /usr/local/bin", command="ls -ld /usr/local/bin"),
     Commands(
         name="file permission to /usr/local/bin (create)", command="touch /usr/local/bin/test_file"

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -24,6 +24,7 @@ class Commands:
 # This is matched with E2E test run of github-runner-operator charm.
 TEST_RUNNER_COMMANDS = (
     Commands(name="simple hello world", command="echo hello world"),
+    Commands(name="print groups", command="groups"),
     Commands(name="file permission to /usr/local/bin", command="ls -ld /usr/local/bin"),
     Commands(
         name="file permission to /usr/local/bin (create)", command="touch /usr/local/bin/test_file"

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -496,7 +496,7 @@ function configure_system_users() {
     echo "PATH=\\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.profile
     echo "PATH=\\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.bashrc
     /usr/sbin/groupadd microk8s
-    /usr/sbin/usermod --append --groups docker,microk8s,lxd ubuntu
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
 }
 
 function configure_usr_local_bin() {


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Add runner user to sudoers group

### Rationale

Expected behavior for multipass.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
