### PR TITLE
hotfix: go modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/builder.md
+++ b/src-docs/builder.md
@@ -1,0 +1,66 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/builder.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `builder`
+Module for interacting with qemu image builder. 
+
+**Global Variables**
+---------------
+- **IMAGE_DEFAULT_APT_PACKAGES**
+- **APT_DEPENDENCIES**
+- **APT_NONINTERACTIVE_ENV**
+- **SNAP_GO**
+- **RESIZE_AMOUNT**
+- **APT_TIMER**
+- **APT_SVC**
+- **APT_UPGRADE_TIMER**
+- **APT_UPGRAD_SVC**
+- **UBUNTU_USER**
+- **DOCKER_GROUP**
+- **MICROK8S_GROUP**
+- **LXD_GROUP**
+- **SUDOERS_GROUP**
+- **YQ_REPOSITORY_URL**
+- **IMAGE_HWE_PKG_FORMAT**
+
+---
+
+<a href="../src/github_runner_image_builder/builder.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `initialize`
+
+```python
+initialize() → None
+```
+
+Configure the host machine to build images. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/builder.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `run`
+
+```python
+run(arch: Arch, base_image: BaseImage, runner_version: str) → None
+```
+
+Build and save the image locally. 
+
+
+
+**Args:**
+ 
+ - <b>`arch`</b>:  The CPU architecture to build the image for. 
+ - <b>`base_image`</b>:  The ubuntu image to use as build base. 
+ - <b>`runner_version`</b>:  The GitHub runner version to embed. 
+
+
+
+**Raises:**
+ 
+ - <b>`BuildImageError`</b>:  If there was an error building the image. 
+
+

--- a/src-docs/chroot.md
+++ b/src-docs/chroot.md
@@ -1,0 +1,73 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/chroot.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `chroot`
+Context manager for chrooting. 
+
+**Global Variables**
+---------------
+- **CHROOT_DEVICE_DIR**
+- **CHROOT_SHARED_DIRS**
+
+
+---
+
+<a href="../src/github_runner_image_builder/chroot.py#L17"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ChrootBaseError`
+Represents the errors with chroot. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/chroot.py#L21"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `MountError`
+Represents an error while (un)mounting shared dirs. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/chroot.py#L25"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `SyncError`
+Represents an error while syncing chroot dir. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/chroot.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ChrootContextManager`
+A helper class for managing chroot environments. 
+
+<a href="../src/github_runner_image_builder/chroot.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `__init__`
+
+```python
+__init__(chroot_path: Path)
+```
+
+Initialize the chroot context manager. 
+
+
+
+**Args:**
+ 
+ - <b>`chroot_path`</b>:  The path to set as new root. 
+
+
+
+
+

--- a/src-docs/cli.md
+++ b/src-docs/cli.md
@@ -1,0 +1,14 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/cli.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `cli`
+Main entrypoint for github-runner-image-builder cli application. 
+
+**Global Variables**
+---------------
+- **click**
+- **BASE_CHOICES**
+- **LOG_LEVELS**
+
+

--- a/src-docs/cloud_image.md
+++ b/src-docs/cloud_image.md
@@ -1,0 +1,42 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/cloud_image.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `cloud_image`
+Module for downloading images from cloud-images.ubuntu.com. 
+
+**Global Variables**
+---------------
+- **CHECKSUM_BUF_SIZE**
+
+---
+
+<a href="../src/github_runner_image_builder/cloud_image.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `download_and_validate_image`
+
+```python
+download_and_validate_image(arch: Arch, base_image: BaseImage) → Path
+```
+
+Download and verify the base image from cloud-images.ubuntu.com. 
+
+
+
+**Args:**
+ 
+ - <b>`arch`</b>:  The base image architecture to download. 
+ - <b>`base_image`</b>:  The ubuntu base image OS to download. 
+
+
+
+**Returns:**
+ The downloaded image path. 
+
+
+
+**Raises:**
+ 
+ - <b>`BaseImageDownloadError`</b>:  If there was an error with downloading/verifying the image. 
+
+

--- a/src-docs/config.md
+++ b/src-docs/config.md
@@ -1,0 +1,77 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/config.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `config`
+Module containing configurations. 
+
+**Global Variables**
+---------------
+- **ARCHITECTURES_ARM64**
+- **ARCHITECTURES_X86**
+- **LTS_IMAGE_VERSION_TAG_MAP**
+- **BASE_CHOICES**
+- **IMAGE_DEFAULT_APT_PACKAGES**
+- **LOG_LEVELS**
+
+---
+
+<a href="../src/github_runner_image_builder/config.py#L45"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `get_supported_arch`
+
+```python
+get_supported_arch() → <enum 'Arch'>
+```
+
+Get current machine architecture. 
+
+
+
+**Raises:**
+ 
+ - <b>`UnsupportedArchitectureError`</b>:  if the current architecture is unsupported. 
+
+
+
+**Returns:**
+ 
+ - <b>`Arch`</b>:  Current machine architecture. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/config.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `Arch`
+Supported system architectures. 
+
+
+
+**Attributes:**
+ 
+ - <b>`ARM64`</b>:  Represents an ARM64 system architecture. 
+ - <b>`X64`</b>:  Represents an X64/AMD64 system architecture. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/config.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `BaseImage`
+The ubuntu OS base image to build and deploy runners on. 
+
+
+
+**Attributes:**
+ 
+ - <b>`JAMMY`</b>:  The jammy ubuntu LTS image. 
+ - <b>`NOBLE`</b>:  The noble ubuntu LTS image. 
+
+
+
+
+

--- a/src-docs/errors.md
+++ b/src-docs/errors.md
@@ -1,0 +1,328 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/errors.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `errors`
+Module containing error definitions. 
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L7"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ImageBuilderBaseError`
+Represents an error with any builder related executions. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L11"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `BuilderInitializeError`
+Represents an error while setting up host machine as builder. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `DependencyInstallError`
+Represents an error while installing required dependencies. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L20"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `NetworkBlockDeviceError`
+Represents an error while enabling network block device. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L24"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `UnsupportedArchitectureError`
+Raised when given machine architecture is unsupported. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L28"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `BuildImageError`
+Represents an error while building the image. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `UnmountBuildPathError`
+Represents an error while unmounting build path. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L36"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `BaseImageDownloadError`
+Represents an error downloading base image. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ImageResizeError`
+Represents an error while resizing the image. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ImageConnectError`
+Represents an error while connecting the image to network block device. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ResizePartitionError`
+Represents an error while resizing network block device partitions. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `UnattendedUpgradeDisableError`
+Represents an error while disabling unattended-upgrade related services. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `SystemUserConfigurationError`
+Represents an error while adding user to chroot env. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `PermissionConfigurationError`
+Represents an error while modifying dir permissions. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `YQBuildError`
+Represents an error while building yq binary from source. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L68"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `YarnInstallError`
+Represents an error installilng Yarn. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L72"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `RunnerDownloadError`
+Represents an error downloading GitHub runner tar archive. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L76"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `ImageCompressError`
+Represents an error while compressing cloud-img. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `OpenstackBaseError`
+Represents an error while interacting with Openstack. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `UnauthorizedError`
+Represents an unauthorized connection to Openstack. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L88"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `UploadImageError`
+Represents an error when uploading image to Openstack. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `OpenstackError`
+Represents an error while communicating with Openstack. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `CloudsYAMLError`
+Represents an error with clouds.yaml for OpenStack connection. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `NotFoundError`
+Represents an error with not matching OpenStack object found. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `FlavorNotFoundError`
+Represents an error with given OpenStack flavor not found. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L108"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `FlavorRequirementsNotMetError`
+Represents an error with given OpenStack flavor not meeting the minimum requirements. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L112"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `NetworkNotFoundError`
+Represents an error with given OpenStack network not found. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `AddressNotFoundError`
+Represents an error with OpenStack instance not receiving an IP address. 
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/errors.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `CloudInitFailError`
+Represents an error with cloud-init. 
+
+
+
+
+

--- a/src-docs/openstack_builder.md
+++ b/src-docs/openstack_builder.md
@@ -1,0 +1,137 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/openstack_builder.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `openstack_builder`
+Module for interacting with external openstack VM image builder. 
+
+**Global Variables**
+---------------
+- **IMAGE_DEFAULT_APT_PACKAGES**
+- **CLOUD_YAML_PATHS**
+- **BUILDER_SSH_KEY_NAME**
+- **SHARED_SECURITY_GROUP_NAME**
+- **IMAGE_SNAPSHOT_NAME**
+- **CREATE_SERVER_TIMEOUT**
+- **MIN_CPU**
+- **MIN_RAM**
+- **MIN_DISK**
+
+---
+
+<a href="../src/github_runner_image_builder/openstack_builder.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `determine_cloud`
+
+```python
+determine_cloud(cloud_name: str | None = None) → str
+```
+
+Automatically determine cloud to use from clouds.yaml by selecting the first cloud. 
+
+
+
+**Args:**
+ 
+ - <b>`cloud_name`</b>:  str 
+
+
+
+**Raises:**
+ 
+ - <b>`CloudsYAMLError`</b>:  if clouds.yaml was not found. 
+
+
+
+**Returns:**
+ The cloud name to use. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/openstack_builder.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `initialize`
+
+```python
+initialize(arch: Arch, cloud_name: str) → None
+```
+
+Initialize the OpenStack external image builder. 
+
+Upload ubuntu base images to openstack to use as builder base. This is a separate method to mitigate race conditions from happening during parallel runs (multiprocess) of the image builder, by creating shared resources beforehand. 
+
+
+
+**Args:**
+ 
+ - <b>`arch`</b>:  The architecture of the image to seed. 
+ - <b>`cloud_name`</b>:  The cloud to use from the clouds.yaml file. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/openstack_builder.py#L208"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `run`
+
+```python
+run(
+    arch: Arch,
+    base: BaseImage,
+    cloud_config: CloudConfig,
+    runner_version: str,
+    keep_revisions: int
+) → str
+```
+
+Run external OpenStack builder instance and create a snapshot. 
+
+
+
+**Args:**
+ 
+ - <b>`arch`</b>:  The architecture of the image to seed. 
+ - <b>`base`</b>:  The Ubuntu base to use as builder VM base. 
+ - <b>`cloud_config`</b>:  The OpenStack cloud configuration values for builder VM. 
+ - <b>`runner_version`</b>:  The GitHub runner version to install on the VM. Defaults to latest. 
+ - <b>`keep_revisions`</b>:  The number of image to keep for snapshot before deletion. 
+
+
+
+**Returns:**
+ The Openstack snapshot image ID. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/openstack_builder.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `CloudConfig`
+The OpenStack cloud configuration values. 
+
+
+
+**Attributes:**
+ 
+ - <b>`cloud_name`</b>:  The OpenStack cloud name to use. 
+ - <b>`flavor`</b>:  The OpenStack flavor to launch builder VMs on. 
+ - <b>`network`</b>:  The OpenStack network to launch the builder VMs on. 
+ - <b>`proxy`</b>:  The proxy to enable on builder VMs. 
+
+<a href="../<string>"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `__init__`
+
+```python
+__init__(cloud_name: str, flavor: str, network: str, proxy: str) → None
+```
+
+
+
+
+
+
+
+
+

--- a/src-docs/store.md
+++ b/src-docs/store.md
@@ -1,0 +1,111 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/store.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `store`
+Module for uploading images to shareable storage. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/store.py#L22"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `create_snapshot`
+
+```python
+create_snapshot(
+    cloud_name: str,
+    image_name: str,
+    server: Server,
+    keep_revisions: int
+) → Image
+```
+
+Upload image to openstack glance. 
+
+
+
+**Args:**
+ 
+ - <b>`cloud_name`</b>:  The Openstack cloud to use from clouds.yaml. 
+ - <b>`image_name`</b>:  The image name to upload as. 
+ - <b>`server`</b>:  The running OpenStack server to snapshot. 
+ - <b>`keep_revisions`</b>:  The number of revisions to keep for an image. 
+
+
+
+**Raises:**
+ 
+ - <b>`UploadImageError`</b>:  If there was an error uploading the image to Openstack Glance. 
+
+
+
+**Returns:**
+ The created image. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/store.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `upload_image`
+
+```python
+upload_image(
+    arch: Arch,
+    cloud_name: str,
+    image_name: str,
+    image_path: Path,
+    keep_revisions: int
+) → str
+```
+
+Upload image to openstack glance. 
+
+
+
+**Args:**
+ 
+ - <b>`arch`</b>:  The image architecture. 
+ - <b>`cloud_name`</b>:  The Openstack cloud to use from clouds.yaml. 
+ - <b>`image_name`</b>:  The image name to upload as. 
+ - <b>`image_path`</b>:  The path to image to upload. 
+ - <b>`keep_revisions`</b>:  The number of revisions to keep for an image. 
+
+
+
+**Raises:**
+ 
+ - <b>`UploadImageError`</b>:  If there was an error uploading the image to Openstack Glance. 
+
+
+
+**Returns:**
+ The created image ID. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/store.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `get_latest_build_id`
+
+```python
+get_latest_build_id(cloud_name: str, image_name: str) → str
+```
+
+Fetch the latest image id. 
+
+
+
+**Args:**
+ 
+ - <b>`cloud_name`</b>:  The Openstack cloud to use from clouds.yaml. 
+ - <b>`image_name`</b>:  The image name to search for. 
+
+
+
+**Returns:**
+ The image ID if exists, None otherwise. 
+
+

--- a/src-docs/utils.md
+++ b/src-docs/utils.md
@@ -1,0 +1,44 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/github_runner_image_builder/utils.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `utils`
+Utilities used by the app. 
+
+
+---
+
+<a href="../src/github_runner_image_builder/utils.py#L23"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `retry`
+
+```python
+retry(
+    exception: Type[Exception] = <class 'Exception'>,
+    tries: int = 1,
+    delay: float = 0,
+    max_delay: Optional[float] = None,
+    backoff: float = 1,
+    local_logger: Logger = <Logger utils (INFO)>
+) → Callable[[Callable[~ParamT, ~ReturnT]], Callable[~ParamT, ~ReturnT]]
+```
+
+Parameterize the decorator for adding retry to functions. 
+
+
+
+**Args:**
+ 
+ - <b>`exception`</b>:  Exception type to be retried. 
+ - <b>`tries`</b>:  Number of attempts at retry. 
+ - <b>`delay`</b>:  Time in seconds to wait between retry. 
+ - <b>`max_delay`</b>:  Max time in seconds to wait between retry. 
+ - <b>`backoff`</b>:  Factor to increase the delay by each retry. 
+ - <b>`local_logger`</b>:  Logger for logging. 
+
+
+
+**Returns:**
+ The function decorator for retry. 
+
+

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -436,6 +436,11 @@ def _install_yq() -> None:
             )
             logger.info("git pull out: %s", output)
         output = subprocess.check_output(  # nosec: B603
+            ["/snap/bin/go", "mod tidy", "-C", str(YQ_REPOSITORY_PATH)],
+            timeout=20 * 60,
+        )
+        logger.info("go mod tidy out: %s", output)
+        output = subprocess.check_output(  # nosec: B603
             ["/snap/bin/go", "build", "-C", str(YQ_REPOSITORY_PATH), "-o", str(HOST_YQ_BIN_PATH)],
             timeout=20 * 60,
         )

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -71,6 +71,7 @@ function install_yarn() {
 function install_yq() {
     /usr/bin/sudo snap install go --classic
     /usr/bin/git clone https://github.com/mikefarah/yq.git
+    /snap/bin/go mod tidy -C yq
     /snap/bin/go build -C yq -o /usr/bin/yq
     /usr/bin/rm -rf yq
     /usr/bin/sudo snap remove go

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -513,6 +513,7 @@ function install_yarn() {
 function install_yq() {
     /usr/bin/sudo snap install go --classic
     /usr/bin/git clone https://github.com/mikefarah/yq.git
+    /snap/bin/go mod tidy -C yq
     /snap/bin/go build -C yq -o /usr/bin/yq
     /usr/bin/rm -rf yq
     /usr/bin/sudo snap remove go


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Run go mod tidy before building go binary

### Rationale

YQ go modules have been updated and requires tidy-ing before buid.

### Module Changes

None

### Library/Dependency Changes

None

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
