### PR TITLE
hotfix: yq source build error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.4.4"
+version = "0.4.5"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -423,23 +423,12 @@ def _install_yq() -> None:
         YQBuildError: If there was an error building yq from source.
     """
     try:
-        if not YQ_REPOSITORY_PATH.exists():
-            output = subprocess.check_output(  # nosec: B603
-                ["/usr/bin/git", "clone", str(YQ_REPOSITORY_URL), str(YQ_REPOSITORY_PATH)],
-                timeout=60 * 10,
-            )
-            logger.info("git clone out: %s", output)
-        else:
-            output = subprocess.check_output(  # nosec: B603
-                ["/usr/bin/git", "-C", str(YQ_REPOSITORY_PATH), "pull"],
-                timeout=60 * 10,
-            )
-            logger.info("git pull out: %s", output)
+        shutil.rmtree(YQ_REPOSITORY_PATH, ignore_errors=True)
         output = subprocess.check_output(  # nosec: B603
-            ["/snap/bin/go", "mod", "tidy", "-C", str(YQ_REPOSITORY_PATH)],
-            timeout=20 * 60,
+            ["/usr/bin/git", "clone", str(YQ_REPOSITORY_URL), str(YQ_REPOSITORY_PATH)],
+            timeout=60 * 10,
         )
-        logger.info("go mod tidy out: %s", output)
+        logger.info("git clone out: %s", output)
         output = subprocess.check_output(  # nosec: B603
             ["/snap/bin/go", "build", "-C", str(YQ_REPOSITORY_PATH), "-o", str(HOST_YQ_BIN_PATH)],
             timeout=20 * 60,

--- a/src/github_runner_image_builder/builder.py
+++ b/src/github_runner_image_builder/builder.py
@@ -430,6 +430,11 @@ def _install_yq() -> None:
         )
         logger.info("git clone out: %s", output)
         output = subprocess.check_output(  # nosec: B603
+            ["/snap/bin/go", "mod", "-C", str(YQ_REPOSITORY_PATH), "tidy"],
+            timeout=20 * 60,
+        )
+        logger.info("go mod tidy out: %s", output)
+        output = subprocess.check_output(  # nosec: B603
             ["/snap/bin/go", "build", "-C", str(YQ_REPOSITORY_PATH), "-o", str(HOST_YQ_BIN_PATH)],
             timeout=20 * 60,
         )

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -141,7 +141,7 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> None:
     "Ignored if --experimental-external is not enabled",
 )
 # click doesn't yet support dataclasses, hence all arguments are required.
-def run(  # pylint: disable=R0917,too-many-arguments
+def run(  # pylint: disable=too-many-arguments, too-many-positional-arguments
     cloud_name: str,
     image_name: str,
     base_image: str,

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -141,7 +141,7 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> None:
     "Ignored if --experimental-external is not enabled",
 )
 # click doesn't yet support dataclasses, hence all arguments are required.
-def run(  # pylint: disable=too-many-arguments
+def run(  # pylint: disable=R0917,too-many-arguments
     cloud_name: str,
     image_name: str,
     base_image: str,

--- a/src/github_runner_image_builder/config.py
+++ b/src/github_runner_image_builder/config.py
@@ -127,7 +127,8 @@ IMAGE_DEFAULT_APT_PACKAGES = [
 
 _LOG_LEVELS = (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR)
 LOG_LEVELS = tuple(
-    itertools.chain(
+    str(level)
+    for level in itertools.chain(
         _LOG_LEVELS,
         (logging.getLevelName(level) for level in _LOG_LEVELS),
         (logging.getLevelName(level).lower() for level in _LOG_LEVELS),

--- a/src/github_runner_image_builder/utils.py
+++ b/src/github_runner_image_builder/utils.py
@@ -20,7 +20,7 @@ ReturnT = TypeVar("ReturnT")
 
 
 # This decorator has default arguments, one extra argument is not a problem.
-def retry(  # pylint: disable=R0917,too-many-arguments
+def retry(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     exception: Type[Exception] = Exception,
     tries: int = 1,
     delay: float = 0,

--- a/src/github_runner_image_builder/utils.py
+++ b/src/github_runner_image_builder/utils.py
@@ -20,7 +20,7 @@ ReturnT = TypeVar("ReturnT")
 
 
 # This decorator has default arguments, one extra argument is not a problem.
-def retry(  # pylint: disable=too-many-arguments
+def retry(  # pylint: disable=R0917,too-many-arguments
     exception: Type[Exception] = Exception,
     tries: int = 1,
     delay: float = 0,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -230,7 +230,7 @@ def _instance_running(instance: Instance) -> bool:
 
 
 # All the arguments are necessary
-async def wait_for_valid_connection(  # pylint: disable=too-many-arguments
+async def wait_for_valid_connection(  # pylint: disable=R0917,too-many-arguments
     connection: Connection,
     server_name: str,
     network: str,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,7 @@
 """Helper utilities for integration tests."""
 
 import collections
+import dataclasses
 import inspect
 import logging
 import platform
@@ -229,12 +230,25 @@ def _instance_running(instance: Instance) -> bool:
     return result.exit_code == 0
 
 
-# All the arguments are necessary
-async def wait_for_valid_connection(  # pylint: disable=R0917,too-many-arguments
-    connection: Connection,
-    server_name: str,
-    network: str,
-    ssh_key: Path,
+@dataclasses.dataclass
+class OpenStackConnectionParams:
+    """Parameters for connecting to OpenStack instance.
+
+    Attributes:
+        connection: The openstack connection client to communicate with Openstack.
+        server_name: Openstack server to find the valid connection from.
+        network: The network to find valid connection from.
+        ssh_key: The path to public ssh_key to create connection with.
+    """
+
+    connection: Connection
+    server_name: str
+    network: str
+    ssh_key: Path
+
+
+async def wait_for_valid_connection(
+    connection_params: OpenStackConnectionParams,
     timeout: int = 30 * 60,
     proxy: types.ProxyConfig | None = None,
     dockerhub_mirror: str | None = None,
@@ -242,10 +256,7 @@ async def wait_for_valid_connection(  # pylint: disable=R0917,too-many-arguments
     """Wait for a valid SSH connection from Openstack server.
 
     Args:
-        connection: The openstack connection client to communicate with Openstack.
-        server_name: Openstack server to find the valid connection from.
-        network: The network to find valid connection from.
-        ssh_key: The path to public ssh_key to create connection with.
+        connection_params: Parameters for connecting to OpenStack instance.
         timeout: Number of seconds to wait before raising a timeout error.
         proxy: The proxy to configure on host runner.
         dockerhub_mirror: The DockerHub mirror URL.
@@ -258,17 +269,23 @@ async def wait_for_valid_connection(  # pylint: disable=R0917,too-many-arguments
     """
     start_time = time.time()
     while time.time() - start_time <= timeout:
-        server: Server | None = connection.get_server(name_or_id=server_name)
+        server: Server | None = connection_params.connection.get_server(
+            name_or_id=connection_params.server_name
+        )
         if not server or not server.addresses:
             time.sleep(10)
             continue
-        for address in server.addresses[network]:
+        for address in server.addresses[connection_params.network]:
             ip = address["addr"]
-            logger.info("Trying SSH into %s using key: %s...", ip, str(ssh_key.absolute()))
+            logger.info(
+                "Trying SSH into %s using key: %s...",
+                ip,
+                str(connection_params.ssh_key.absolute()),
+            )
             ssh_connection = SSHConnection(
                 host=ip,
                 user="ubuntu",
-                connect_kwargs={"key_filename": str(ssh_key.absolute())},
+                connect_kwargs={"key_filename": str(connection_params.ssh_key.absolute())},
                 connect_timeout=10 * 60,
             )
             try:

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -60,10 +60,12 @@ async def ssh_connection_fixture(
     """The openstack server ssh connection fixture."""
     logger.info("Setting up SSH connection.")
     ssh_connection = await helpers.wait_for_valid_connection(
-        connection=openstack_metadata.connection,
-        server_name=openstack_server.name,
-        network=openstack_metadata.network,
-        ssh_key=openstack_metadata.ssh_key.private_key,
+        connection_params=helpers.OpenStackConnectionParams(
+            connection=openstack_metadata.connection,
+            server_name=openstack_server.name,
+            network=openstack_metadata.network,
+            ssh_key=openstack_metadata.ssh_key.private_key,
+        ),
         proxy=proxy,
         dockerhub_mirror=dockerhub_mirror,
     )

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -131,10 +131,12 @@ async def ssh_connection_fixture(
     """The openstack server ssh connection fixture."""
     logger.info("Setting up SSH connection.")
     ssh_connection = await helpers.wait_for_valid_connection(
-        connection=openstack_metadata.connection,
-        server_name=openstack_server.name,
-        network=openstack_metadata.network,
-        ssh_key=openstack_metadata.ssh_key.private_key,
+        connection_params=helpers.OpenStackConnectionParams(
+            connection=openstack_metadata.connection,
+            server_name=openstack_server.name,
+            network=openstack_metadata.network,
+            ssh_key=openstack_metadata.ssh_key.private_key,
+        ),
         proxy=proxy,
         dockerhub_mirror=dockerhub_mirror,
     )


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Hotfix for cloning yq source every build.

### Rationale

- The yq repository changes dependencies often, running go mod clean isn't enough to keep git sane.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
