### PR TITLE
fix: stop server before snapshot (flush to disk)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.5.6"
+version = "0.5.7"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/store.md
+++ b/src-docs/store.md
@@ -46,7 +46,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upload_image`
 
@@ -86,7 +86,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_build_id`
 

--- a/src-docs/store.md
+++ b/src-docs/store.md
@@ -46,7 +46,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L61"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upload_image`
 
@@ -86,7 +86,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_build_id`
 

--- a/src/github_runner_image_builder/store.py
+++ b/src/github_runner_image_builder/store.py
@@ -39,7 +39,8 @@ def create_snapshot(
     with openstack.connect(cloud=cloud_name) as connection:
         try:
             logger.info("Stopping server to snapshot, %s", server.name)
-            server.stop(session=connection.session)
+            connection.compute.stop_server(server=server)
+            connection.compute.wait_for_server(server=server, status="SHUTOFF", wait=5 * 60)
             logger.info("Creating image snapshot, %s %s", image_name, server.name)
             image: Image = connection.create_image_snapshot(
                 name=image_name,

--- a/src/github_runner_image_builder/store.py
+++ b/src/github_runner_image_builder/store.py
@@ -38,6 +38,8 @@ def create_snapshot(
     """
     with openstack.connect(cloud=cloud_name) as connection:
         try:
+            logger.info("Stopping server to snapshot, %s", server.name)
+            server.stop(session=connection.session)
             logger.info("Creating image snapshot, %s %s", image_name, server.name)
             image: Image = connection.create_image_snapshot(
                 name=image_name,

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -24,6 +24,8 @@ class Commands:
 # This is matched with E2E test run of github-runner-operator charm.
 TEST_RUNNER_COMMANDS = (
     Commands(name="simple hello world", command="echo hello world"),
+    # skopeo does not exist by default, apt-get update must be run before
+    Commands(name="apt updated", command="sudo apt install -y skopeo"),
     Commands(name="print groups", command="groups | grep sudo"),
     Commands(name="file permission to /usr/local/bin", command="ls -ld /usr/local/bin"),
     Commands(


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- fixes bug where apt update is not applied on the snapshot server due to non-flushed disk snapshot.

### Rationale

- openstack documentation guides the server to be shutoff before snapshot is taken

### Module Changes

- store.py - stop server before snapshot

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
