### PR TITLE
fix: use different file-path for parallel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.5.6"
+version = "0.5.7"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/openstack_builder.md
+++ b/src-docs/openstack_builder.md
@@ -9,7 +9,6 @@ Module for interacting with external openstack VM image builder.
 ---------------
 - **IMAGE_DEFAULT_APT_PACKAGES**
 - **CLOUD_YAML_PATHS**
-- **BUILDER_SSH_KEY_NAME**
 - **SHARED_SECURITY_GROUP_NAME**
 - **CREATE_SERVER_TIMEOUT**
 - **MIN_CPU**
@@ -18,7 +17,7 @@ Module for interacting with external openstack VM image builder.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `determine_cloud`
 
@@ -48,12 +47,12 @@ Automatically determine cloud to use from clouds.yaml by selecting the first clo
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L88"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `initialize`
 
 ```python
-initialize(arch: Arch, cloud_name: str) → None
+initialize(arch: Arch, cloud_name: str, prefix: str) → None
 ```
 
 Initialize the OpenStack external image builder. 
@@ -66,11 +65,12 @@ Upload ubuntu base images to openstack to use as builder base. This is a separat
  
  - <b>`arch`</b>:  The architecture of the image to seed. 
  - <b>`cloud_name`</b>:  The cloud to use from the clouds.yaml file. 
+ - <b>`prefix`</b>:  The prefix to use for OpenStack resource names. 
 
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L211"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -100,7 +100,7 @@ Run external OpenStack builder instance and create a snapshot.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L206"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `CloudConfig`
 The OpenStack cloud configuration values. 
@@ -112,6 +112,7 @@ The OpenStack cloud configuration values.
  - <b>`cloud_name`</b>:  The OpenStack cloud name to use. 
  - <b>`flavor`</b>:  The OpenStack flavor to launch builder VMs on. 
  - <b>`network`</b>:  The OpenStack network to launch the builder VMs on. 
+ - <b>`prefix`</b>:  The prefix to use for OpenStack resource names. 
  - <b>`proxy`</b>:  The proxy to enable on builder VMs. 
  - <b>`upload_cloud_names`</b>:  The OpenStack cloud names to upload the snapshot to. (Defaults to             the same cloud) 
 
@@ -124,6 +125,7 @@ __init__(
     cloud_name: str,
     flavor: str,
     network: str,
+    prefix: str,
     proxy: str,
     upload_cloud_names: Optional[Iterable[str]]
 ) → None

--- a/src-docs/openstack_builder.md
+++ b/src-docs/openstack_builder.md
@@ -18,7 +18,7 @@ Module for interacting with external openstack VM image builder.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `determine_cloud`
 
@@ -48,7 +48,7 @@ Automatically determine cloud to use from clouds.yaml by selecting the first clo
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L90"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `initialize`
 
@@ -70,7 +70,7 @@ Upload ubuntu base images to openstack to use as builder base. This is a separat
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L211"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -100,7 +100,7 @@ Run external OpenStack builder instance and create a snapshot.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `CloudConfig`
 The OpenStack cloud configuration values. 

--- a/src-docs/store.md
+++ b/src-docs/store.md
@@ -86,7 +86,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_build_id`
 

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -42,9 +42,7 @@ CLOUD_YAML_PATHS = (
     pathlib.Path("/etc/openstack/clouds.yaml"),
 )
 
-BUILDER_SSH_KEY_NAME = "image-builder-ssh-key"
 BUILDER_KEY_PATH = pathlib.Path("/home/ubuntu/.ssh/builder_key")
-
 SHARED_SECURITY_GROUP_NAME = "github-runner-image-builder-v1"
 
 CREATE_SERVER_TIMEOUT = 5 * 60  # seconds
@@ -87,7 +85,7 @@ def determine_cloud(cloud_name: str | None = None) -> str:
     return cloud
 
 
-def initialize(arch: Arch, cloud_name: str) -> None:
+def initialize(arch: Arch, cloud_name: str, prefix: str) -> None:
     """Initialize the OpenStack external image builder.
 
     Upload ubuntu base images to openstack to use as builder base. This is a separate method to
@@ -97,6 +95,7 @@ def initialize(arch: Arch, cloud_name: str) -> None:
     Args:
         arch: The architecture of the image to seed.
         cloud_name: The cloud to use from the clouds.yaml file.
+        prefix: The prefix to use for OpenStack resource names.
     """
     logger.info("Initializing external builder.")
     logger.info("Downloading Jammy image.")
@@ -125,8 +124,7 @@ def initialize(arch: Arch, cloud_name: str) -> None:
     )
 
     with openstack.connect(cloud=cloud_name) as conn:
-        logger.info("Creating keypair %s.", BUILDER_SSH_KEY_NAME)
-        _create_keypair(conn=conn)
+        _create_keypair(conn=conn, prefix=prefix)
         logger.info("Creating security group %s.", SHARED_SECURITY_GROUP_NAME)
         _create_security_group(conn=conn)
 
@@ -144,20 +142,37 @@ def _get_base_image_name(arch: Arch, base: BaseImage) -> str:
     return f"image-builder-base-{base.value}-{arch.value}"
 
 
-def _create_keypair(conn: openstack.connection.Connection) -> None:
+def _create_keypair(conn: openstack.connection.Connection, prefix: str) -> None:
     """Create an SSH Keypair to ssh into builder instance.
 
     Args:
         conn: The Openstach connection instance.
+        prefix: The prefix to use for OpenStack resource names.
     """
-    key = conn.get_keypair(name_or_id=BUILDER_SSH_KEY_NAME)
+    key_name = _get_keyname(prefix=prefix)
+    key = conn.get_keypair(name_or_id=key_name)
     if key and BUILDER_KEY_PATH.exists():
         return
-    conn.delete_keypair(name=BUILDER_SSH_KEY_NAME)
-    keypair = conn.create_keypair(name=BUILDER_SSH_KEY_NAME)
-    BUILDER_KEY_PATH.write_text(keypair.private_key, encoding="utf-8")
+    logger.info("Deleting existing keypair (to regenerate) %s.", key_name)
+    conn.delete_keypair(name=key_name)
+    logger.info("Creating keypair %s.", key_name)
+    keypair = conn.create_keypair(name=key_name)
+    # OpenStack library does not provide correct type hints for keys.
+    BUILDER_KEY_PATH.write_text(keypair.private_key, encoding="utf-8")  # type: ignore
     shutil.chown(BUILDER_KEY_PATH, user="ubuntu", group="ubuntu")
     BUILDER_KEY_PATH.chmod(0o400)
+
+
+def _get_keyname(prefix: str) -> str:
+    """Get OpenStack key name.
+
+    Args:
+        prefix: The prefix to use for OpenStack resource names.
+
+    Returns:
+        The OpenStack key name.
+    """
+    return f"{prefix}-image-builder-ssh-key"
 
 
 def _create_security_group(conn: openstack.connection.Connection) -> None:
@@ -196,6 +211,7 @@ class CloudConfig:
         cloud_name: The OpenStack cloud name to use.
         flavor: The OpenStack flavor to launch builder VMs on.
         network: The OpenStack network to launch the builder VMs on.
+        prefix: The prefix to use for OpenStack resource names.
         proxy: The proxy to enable on builder VMs.
         upload_cloud_names: The OpenStack cloud names to upload the snapshot to. (Defaults to \
             the same cloud)
@@ -204,6 +220,7 @@ class CloudConfig:
     cloud_name: str
     flavor: str
     network: str
+    prefix: str
     proxy: str
     upload_cloud_names: typing.Iterable[str] | None
 
@@ -236,10 +253,10 @@ def run(
         logger.info("Using network ID: %s.", network)
         builder: openstack.compute.v2.server.Server = conn.create_server(
             name=_get_builder_name(
-                arch=image_config.arch, base=image_config.base, name=image_config.name
+                arch=image_config.arch, base=image_config.base, prefix=cloud_config.prefix
             ),
             image=_get_base_image_name(arch=image_config.arch, base=image_config.base),
-            key_name=BUILDER_SSH_KEY_NAME,
+            key_name=_get_keyname(prefix=cloud_config.prefix),
             flavor=flavor,
             network=network,
             security_groups=[SHARED_SECURITY_GROUP_NAME],
@@ -297,20 +314,32 @@ def _determine_flavor(conn: openstack.connection.Connection, flavor_name: str | 
                 f"Given flavor {flavor_name} not found."
             )
         logger.info("Flavor found, %s", flavor.name)
-        if not (flavor.vcpus >= MIN_CPU and flavor.ram >= MIN_RAM and flavor.disk >= MIN_DISK):
+        # OpenStack library does not provide correct type hints for flavors.
+        if not (
+            flavor.vcpus >= MIN_CPU  # type: ignore
+            and flavor.ram >= MIN_RAM  # type: ignore
+            and flavor.disk >= MIN_DISK  # type: ignore
+        ):
             logger.error("Given flavor %s does not meet the minimum requirements.", flavor_name)
             raise github_runner_image_builder.errors.FlavorRequirementsNotMetError(
                 f"Provided flavor {flavor_name} does not meet the minimum requirements."
                 f"Required: CPU: {MIN_CPU} MEM: {MIN_RAM}M DISK: {MIN_DISK}G. "
                 f"Got: CPU: {flavor.vcpus} MEM: {flavor.ram}M DISK: {flavor.disk}G."
             )
-        return flavor.id
+        # OpenStack library does not provide correct type hints for flavors.
+        return flavor.id  # type: ignore
     flavors: list[openstack.compute.v2.flavor.Flavor] = conn.list_flavors()
     flavors = sorted(flavors, key=lambda flavor: (flavor.vcpus, flavor.ram, flavor.disk))
     for flavor in flavors:
-        if flavor.vcpus >= MIN_CPU and flavor.ram >= MIN_RAM and flavor.disk >= MIN_DISK:
+        # OpenStack library does not provide correct type hints for flavors.
+        if (
+            flavor.vcpus >= MIN_CPU  # type: ignore
+            and flavor.ram >= MIN_RAM  # type: ignore
+            and flavor.disk >= MIN_DISK  # type: ignore
+        ):
             logger.info("Flavor found, %s", flavor.name)
-            return flavor.id
+            # OpenStack library does not provide correct type hints for flavors.
+            return flavor.id  # type: ignore
     raise github_runner_image_builder.errors.FlavorNotFoundError("No suitable flavor found.")
 
 
@@ -334,7 +363,8 @@ def _determine_network(conn: openstack.connection.Connection, network_name: str 
                 f"Given network {network_name} not found."
             )
         logger.info("Network found, %s", network.name)
-        return network.id
+        # OpenStack library does not provide correct type hints for networks.
+        return network.id  # type: ignore
     networks: list[openstack.network.v2.network.Network] = conn.list_networks()
     # Only a single valid subnet should exist per environment.
     subnets: list[openstack.network.v2.subnet.Subnet] = conn.list_subnets()
@@ -343,9 +373,11 @@ def _determine_network(conn: openstack.connection.Connection, network_name: str 
         raise github_runner_image_builder.errors.NetworkNotFoundError("No valid subnets found.")
     subnet = subnets[0]
     for network in networks:
-        if subnet.id in network.subnet_ids:
+        # OpenStack library does not provide correct type hints for networks.
+        if subnet.id in network.subnet_ids:  # type: ignore
             logger.info("Network found, %s", network.name)
-            return network.id
+            # OpenStack library does not provide correct type hints for networks.
+            return network.id  # type: ignore
     raise github_runner_image_builder.errors.NetworkNotFoundError("No suitable network found.")
 
 
@@ -380,18 +412,18 @@ def _generate_cloud_init_script(
     )
 
 
-def _get_builder_name(arch: Arch, base: BaseImage, name: str) -> str:
+def _get_builder_name(arch: Arch, base: BaseImage, prefix: str) -> str:
     """Get builder VM name.
 
     Args:
         arch: The architecture of the image to seed.
         base: The ubuntu base image.
-        name: The name of the target image to build.
+        prefix: The prefix to use for OpenStack resource names.
 
     Returns:
         The builder VM name launched on OpenStack.
     """
-    return f"image-builder-{base.value}-{arch.value}-{name}"
+    return f"{prefix}-image-builder-{base.value}-{arch.value}"
 
 
 @tenacity.retry(
@@ -445,8 +477,9 @@ def _get_ssh_connection(
     Returns:
         The SSH Connection instance.
     """
-    server = conn.get_server(name_or_id=server.id)
-    network_address_list = server.addresses.values()
+    # OpenStack library does not provide correct type hints for it.
+    server = conn.get_server(name_or_id=server.id)  # type: ignore
+    network_address_list = server.addresses.values()  # type: ignore
     if not network_address_list:
         logger.error("Server address not found, %s.", server.name)
         raise github_runner_image_builder.errors.AddressNotFoundError(
@@ -508,11 +541,13 @@ def _wait_for_snapshot_complete(
         TimeoutError: if the image snapshot took too long to complete.
     """
     for _ in range(10):
-        image = conn.get_image(name_or_id=image.id)
+        # OpenStack library does not provide correct type hints for it.
+        image = conn.get_image(name_or_id=image.id)  # type: ignore
         if image.status == "active":
             return
         time.sleep(60)
-    image = conn.get_image(name_or_id=image.id)
+    # OpenStack library does not provide correct type hints for it.
+    image = conn.get_image(name_or_id=image.id)  # type: ignore
     if not image or not image.status == "active":
         logger.error("Timed out waiting for snapshot to be active, %s.", image.name)
         raise TimeoutError(f"Timed out waiting for snapshot to be active, {image.id}.")
@@ -535,10 +570,10 @@ class _UploadCloudConfig:
 
 def _upload_to_clouds(
     conn: openstack.connection.Connection,
-    image: openstack.compute.v2.image.Image,
+    image: openstack.image.v2.image.Image,
     upload_cloud_names: typing.Iterable[str] | None,
     upload_cloud_config: _UploadCloudConfig,
-) -> tuple[openstack.compute.v2.image.Image, ...]:
+) -> tuple[openstack.image.v2.image.Image, ...]:
     """Upload the snapshot image to different clouds.
 
     Args:
@@ -555,7 +590,7 @@ def _upload_to_clouds(
     file_path = pathlib.Path(f"{image.name}.snapshot")
     logger.info("Downloading snapshot to %s.", file_path)
     conn.download_image(name_or_id=image.id, output_file=file_path, stream=True)
-    images: list[openstack.compute.v2.image.Image] = []
+    images: list[openstack.image.v2.image.Image] = []
     for cloud_name in upload_cloud_names:
         logger.info("Uploading downloaded snapshot to %s.", cloud_name)
         image = store.upload_image(

--- a/src/github_runner_image_builder/store.py
+++ b/src/github_runner_image_builder/store.py
@@ -76,13 +76,15 @@ def upload_image(
     with openstack.connect(cloud=cloud_name) as connection:
         try:
             logger.info("Uploading image %s.", image_name)
+            # ignore type since the library does not provide correct type hinting but the docstring
+            # does define the return type.
             image: Image = connection.create_image(
                 name=image_name,
                 filename=str(image_path),
                 properties={"architecture": arch.to_openstack()},
                 allow_duplicates=True,
                 wait=True,
-            )
+            )  # type: ignore
             logger.info("Pruning older images %s, keeping %s.", image_name, keep_revisions)
             _prune_old_images(
                 connection=connection, image_name=image_name, num_revisions=keep_revisions
@@ -134,7 +136,8 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> str:
         images = _get_sorted_images_by_created_at(connection=connection, image_name=image_name)
         if not images:
             return ""
-        return images[0].id
+        # The type of ID is in string but the library does not provide correct type hints for it.
+        return images[0].id  # type: ignore
 
 
 def _get_sorted_images_by_created_at(
@@ -158,4 +161,6 @@ def _get_sorted_images_by_created_at(
         logger.exception("Failed to search images with name %s.", image_name)
         raise OpenstackError from exc
 
-    return sorted(images, key=lambda image: image.created_at, reverse=True)
+    # The type of images are list[Image] but the library does not provide correct type hints for
+    # it.
+    return sorted(images, key=lambda image: image.created_at, reverse=True)  # type: ignore

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,6 +49,12 @@ def image_fixture(pytestconfig: pytest.Config) -> str:
     return image
 
 
+@pytest.fixture(scope="module", name="image_config")
+def image_config_fixture(arch: config.Arch, image: str):
+    """The image related configuration parameters."""
+    return types.ImageConfig(arch=arch, image=image)
+
+
 @pytest.fixture(scope="module", name="openstack_clouds_yaml")
 def openstack_clouds_yaml_fixture(pytestconfig: pytest.Config) -> str:
     """Configured clouds-yaml setting."""
@@ -226,11 +232,19 @@ def ssh_key_fixture(
 
 @pytest.fixture(scope="module", name="openstack_metadata")
 def openstack_metadata_fixture(
-    openstack_connection: Connection, ssh_key: types.SSHKey, network_name: str, flavor_name: str
+    openstack_connection: Connection,
+    ssh_key: types.SSHKey,
+    network_name: str,
+    flavor_name: str,
+    cloud_name: str,
 ) -> types.OpenstackMeta:
     """A wrapper around openstack related info."""
     return types.OpenstackMeta(
-        connection=openstack_connection, ssh_key=ssh_key, network=network_name, flavor=flavor_name
+        connection=openstack_connection,
+        cloud_name=cloud_name,
+        ssh_key=ssh_key,
+        network=network_name,
+        flavor=flavor_name,
     )
 
 

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from openstack.compute.v2.keypair import Keypair
 from openstack.connection import Connection
 
+from github_runner_image_builder import config
+
 
 class ProxyConfig(typing.NamedTuple):
     """Proxy configuration.
@@ -63,12 +65,26 @@ class OpenstackMeta(typing.NamedTuple):
 
     Attributes:
         connection: The connection instance to Openstack.
+        cloud_name: The OpenStack cloud name to connect to.
         ssh_key: The SSH-Key created to connect to Openstack instance.
         network: The Openstack network to create instances under.
         flavor: The flavor to create instances with.
     """
 
     connection: Connection
+    cloud_name: str
     ssh_key: SSHKey
     network: str
     flavor: str
+
+
+class ImageConfig(typing.NamedTuple):
+    """The image related configuration parameters.
+
+    Attributes:
+        arch: The architecture to build for.
+        image: The ubuntu base image.
+    """
+
+    arch: config.Arch
+    image: str

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -112,7 +112,9 @@ def test_initialize(monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner, flag
     if not flags:
         mock_builder_init_func.assert_called_with()
     else:
-        mock_openstack_init_func.assert_called_with(arch=config.Arch.X64, cloud_name="hello")
+        mock_openstack_init_func.assert_called_with(
+            arch=config.Arch.X64, cloud_name="hello", prefix=""
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -93,7 +93,7 @@ def test_initialize(monkeypatch: pytest.MonkeyPatch):
         openstack_builder, "_create_security_group", (create_security_group_mock := MagicMock())
     )
 
-    openstack_builder.initialize(MagicMock(), MagicMock())
+    openstack_builder.initialize(MagicMock(), MagicMock(), MagicMock())
 
     download_mock.assert_called()
     upload_mock.assert_called()
@@ -113,7 +113,7 @@ def test__create_keypair_already_exists(monkeypatch: pytest.MonkeyPatch, tmp_pat
     monkeypatch.setattr(openstack_builder, "BUILDER_KEY_PATH", tmp_key_path)
     connection_mock = MagicMock()
 
-    openstack_builder._create_keypair(conn=connection_mock)
+    openstack_builder._create_keypair(conn=connection_mock, prefix="")
 
     connection_mock.create_keypair.assert_not_called()
 
@@ -132,7 +132,7 @@ def test__create_keypair(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
     connection_mock.create_keypair.return_value = (mock_key := MagicMock())
     mock_key.private_key = "ssh-key-contents"
 
-    openstack_builder._create_keypair(conn=connection_mock)
+    openstack_builder._create_keypair(conn=connection_mock, prefix="")
 
     connection_mock.create_keypair.assert_called()
     assert tmp_path.exists()
@@ -173,6 +173,7 @@ def test__create_security_group():
                 cloud_name="test-cloud",
                 flavor="test-flavor",
                 network="test-network",
+                prefix="",
                 proxy="test-proxy",
                 upload_cloud_names=[],
             ),
@@ -183,6 +184,7 @@ def test__create_security_group():
                 cloud_name="test-cloud",
                 flavor="test-flavor",
                 network="test-network",
+                prefix="",
                 proxy="test-proxy",
                 upload_cloud_names=["test-cloud-1"],
             ),
@@ -193,6 +195,7 @@ def test__create_security_group():
                 cloud_name="test-cloud",
                 flavor="test-flavor",
                 network="test-network",
+                prefix="",
                 proxy="test-proxy",
                 upload_cloud_names=["test-cloud-1", "test-cloud-2"],
             ),


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Use non-constant file name, based on image name
- Ignores type errors due to OpenStack library's weak type hinting.

### Rationale

- when calling the CLI with multiprocessing, the filename can be duplicated causing a race condition.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
