### PR TITLE
feat: juju installation & bootstrap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.5.7"
+version = "0.6.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/config.md
+++ b/src-docs/config.md
@@ -88,6 +88,7 @@ The build image configuration values.
  
  - <b>`arch`</b>:  The architecture of the target image. 
  - <b>`base`</b>:  The ubuntu base OS of the image. 
+ - <b>`juju`</b>:  The Juju channel to install and bootstrap. 
  - <b>`runner_version`</b>:  The GitHub runner version to install on the VM. Defaults to latest. 
  - <b>`name`</b>:  The image name to upload on OpenStack. 
 
@@ -96,7 +97,13 @@ The build image configuration values.
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(arch: Arch, base: BaseImage, runner_version: str, name: str) → None
+__init__(
+    arch: Arch,
+    base: BaseImage,
+    juju: str,
+    runner_version: str,
+    name: str
+) → None
 ```
 
 

--- a/src-docs/openstack_builder.md
+++ b/src-docs/openstack_builder.md
@@ -17,7 +17,7 @@ Module for interacting with external openstack VM image builder.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L61"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `determine_cloud`
 
@@ -47,7 +47,7 @@ Automatically determine cloud to use from clouds.yaml by selecting the first clo
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `initialize`
 
@@ -70,7 +70,7 @@ Upload ubuntu base images to openstack to use as builder base. This is a separat
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -100,7 +100,7 @@ Run external OpenStack builder instance and create a snapshot.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L211"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `CloudConfig`
 The OpenStack cloud configuration values. 

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -147,6 +147,12 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> None:
     "Ignored if --experimental-external is not enabled",
 )
 @click.option(
+    "--juju",
+    default="",
+    help="Juju channel to install and bootstrap. E.g. to install Juju 3.1/stable, pass the values "
+    "--juju=3.1/stable",
+)
+@click.option(
     "--network",
     default="",
     help="EXPERIMENTAL: OpenStack network to launch the external build run VMs under. "
@@ -182,6 +188,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
     runner_version: str,
     experimental_external: bool,
     flavor: str,
+    juju: str,
     network: str,
     prefix: str,
     proxy: str,
@@ -200,6 +207,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
         runner_version: GitHub runner version to pin.
         experimental_external: Whether to use external OpenStack builder.
         flavor: The Openstack flavor to create server to build images.
+        juju: The Juju channel to install and bootstrap.
         network: The Openstack network to assign to server to build images.
         prefix: The prefix to use for OpenStack resource names.
         proxy: Proxy to use for external build VMs.
@@ -213,6 +221,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
             image_config=config.ImageConfig(
                 arch=arch,
                 base=base,
+                juju=juju,
                 runner_version=runner_version,
                 name=image_name,
             ),
@@ -240,6 +249,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
             image_config=config.ImageConfig(
                 arch=arch,
                 base=base,
+                juju=juju,
                 runner_version=runner_version,
                 name=image_name,
             ),

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -94,6 +94,32 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> None:
     )
 
 
+# The arguments are necessary input for click validation function.
+def _validate_juju_channel(
+    ctx: click.Context, param: click.Parameter, value: str  # pylint: disable=unused-argument
+) -> str:
+    """Validate juju channel string input.
+
+    Args:
+        ctx: Click context argument.
+        param: Click parameter argument.
+        value: The value passed into --juju option.
+
+    Raises:
+        BadParameter: If invalid juju channel was passed in.
+
+    Returns:
+        The validated Juju channel option.
+    """
+    if not value:
+        return ""
+    try:
+        [version, track] = value.strip().split("/")
+        return f"{version}/{track}"
+    except ValueError as exc:
+        raise click.BadParameter("format must be '<version>/<track>'") from exc
+
+
 @main.command(name="run")
 @click.argument("cloud_name")
 @click.argument("image_name")
@@ -148,6 +174,7 @@ def get_latest_build_id(cloud_name: str, image_name: str) -> None:
 )
 @click.option(
     "--juju",
+    callback=_validate_juju_channel,
     default="",
     help="Juju channel to install and bootstrap. E.g. to install Juju 3.1/stable, pass the values "
     "--juju=3.1/stable",

--- a/src/github_runner_image_builder/config.py
+++ b/src/github_runner_image_builder/config.py
@@ -144,11 +144,13 @@ class ImageConfig:
     Attributes:
         arch: The architecture of the target image.
         base: The ubuntu base OS of the image.
+        juju: The Juju channel to install and bootstrap.
         runner_version: The GitHub runner version to install on the VM. Defaults to latest.
         name: The image name to upload on OpenStack.
     """
 
     arch: Arch
     base: BaseImage
+    juju: str
     runner_version: str
     name: str

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -243,6 +243,7 @@ def run(
     cloud_init_script = _generate_cloud_init_script(
         arch=image_config.arch,
         base=image_config.base,
+        juju=image_config.juju,
         runner_version=image_config.runner_version,
         proxy=cloud_config.proxy,
     )
@@ -384,6 +385,7 @@ def _determine_network(conn: openstack.connection.Connection, network_name: str 
 def _generate_cloud_init_script(
     arch: Arch,
     base: BaseImage,
+    juju: str,
     runner_version: str,
     proxy: str,
 ) -> str:
@@ -392,6 +394,7 @@ def _generate_cloud_init_script(
     Args:
         arch: The GitHub runner architecture to download.
         base: The ubuntu base image.
+        juju: The juju channel to install.
         runner_version: The GitHub runner version to pin.
         proxy: The proxy to enable while setting up the VM.
 
@@ -407,6 +410,7 @@ def _generate_cloud_init_script(
         PROXY_URL=proxy,
         APT_PACKAGES=" ".join(IMAGE_DEFAULT_APT_PACKAGES),
         HWE_VERSION=BaseImage.get_version(base),
+        JUJU_CHANNEL=juju,
         RUNNER_VERSION=runner_version,
         RUNNER_ARCH=arch.value,
     )

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -13,6 +13,7 @@ import time
 import typing
 
 import fabric
+import invoke
 import jinja2
 import openstack
 import openstack.compute.v2.flavor
@@ -533,7 +534,16 @@ def _wait_for_cloud_init_complete(
         Whether the cloud init is complete. Used for tenacity retry to pick up return value.
     """
     ssh_connection = _get_ssh_connection(conn=conn, server=server, ssh_key=ssh_key)
-    result: fabric.Result | None = ssh_connection.run("cloud-init status --wait", timeout=60 * 10)
+    try:
+        result: fabric.Result | None = ssh_connection.run(
+            "cloud-init status --wait", timeout=60 * 10
+        )
+    except invoke.exceptions.UnexpectedExit as exc:
+        log_out = conn.get_server_console(server=server)
+        logger.error("Cloud init output: %s", log_out)
+        raise github_runner_image_builder.errors.CloudInitFailError(
+            f"Unexpected exit code, reason: {exc.reason}, result: {exc.result}"
+        ) from exc
     if not result or not result.ok:
         logger.error("cloud-init status command failure, result: %s.", result)
         raise github_runner_image_builder.errors.CloudInitFailError("Invalid cloud-init status")

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -2,6 +2,8 @@
 
 set -e
 
+hostnamectl set-hostname github-runner
+
 function configure_proxy() {
     local proxy="$1"
     if [[ -z "$proxy" ]]; then
@@ -90,6 +92,17 @@ function install_yq() {
     /usr/bin/sudo -E /usr/bin/snap remove go
 }
 
+function install_juju() {
+    local channel="$1"
+    if [[ -z "$channel" ]]; then
+        echo "Juju channel not provided, skipping installation."
+        return
+    fi
+    /usr/bin/sudo -E /snap/bin/lxd init --auto
+    /usr/bin/sudo -E /usr/bin/snap install juju --channel="$channel"
+    /snap/bin/juju bootstrap localhost localhost
+}
+
 function install_github_runner() {
     version="$1"
     arch="$2"
@@ -118,6 +131,7 @@ apt_packages="{{ APT_PACKAGES }}"
 hwe_version="{{ HWE_VERSION }}"
 github_runner_version="{{ RUNNER_VERSION }}"
 github_runner_arch="{{ RUNNER_ARCH }}"
+juju_channel="{{ JUJU_CHANNEL }}"
 
 configure_proxy "$proxy"
 install_apt_packages "$apt_packages" "$hwe_version"
@@ -131,6 +145,7 @@ export -f install_yq
 su ubuntu -c "bash -c 'install_yq'"
 install_github_runner "$github_runner_version" "$github_runner_arch"
 chown_home
+install_juju "$juju_channel"
 # Make sure the disk is synced for snapshot
 sync
 echo "Finished sync"

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -98,9 +98,9 @@ function install_juju() {
         echo "Juju channel not provided, skipping installation."
         return
     fi
-    /usr/bin/sudo -E /snap/bin/lxd init --auto
-    /usr/bin/sudo -E /usr/bin/snap install juju --channel="$channel"
-    /snap/bin/juju bootstrap localhost localhost
+    /snap/bin/lxd init --auto
+    /usr/bin/snap install juju --channel="$channel"
+    /usr/bin/sudo -E -H -u ubuntu /snap/bin/juju bootstrap localhost localhost
 }
 
 function install_github_runner() {

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -98,6 +98,9 @@ function install_juju() {
         echo "Juju channel not provided, skipping installation."
         return
     fi
+    if ! lxd --version &> /dev/null; then
+        /usr/bin/snap install lxd
+    fi
     /snap/bin/lxd init --auto
     /usr/bin/snap install juju --channel="$channel"
     /usr/bin/sudo -E -H -u ubuntu /snap/bin/juju bootstrap localhost localhost

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -14,11 +14,13 @@ class Commands:
         name: The test name.
         command: The command to execute.
         env: Additional run envs.
+        external: OpenStack VM test only (Chroot unsupported test).
     """
 
     name: str
     command: str
     env: dict | None = None
+    external: bool = False
 
 
 # This is matched with E2E test run of github-runner-operator charm.
@@ -82,8 +84,5 @@ sudo microk8s stop && sudo microk8s start""",
         name="test network congestion policy",
         command="sudo sysctl -a | grep 'net.ipv4.tcp_congestion_control = bbr'",
     ),
-    Commands(
-        name="test juju installed",
-        command="juju version | grep 3.1",
-    ),
+    Commands(name="test juju installed", command="juju version | grep 3.1", external=True),
 )

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -82,4 +82,8 @@ sudo microk8s stop && sudo microk8s start""",
         name="test network congestion policy",
         command="sudo sysctl -a | grep 'net.ipv4.tcp_congestion_control = bbr'",
     ),
+    Commands(
+        name="test juju installed",
+        command="juju version | grep 3.1",
+    ),
 )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -407,14 +407,19 @@ def format_dockerhub_mirror_microk8s_command(command: str, dockerhub_mirror: str
     return command.format(registry_url=url.geturl(), hostname=url.hostname, port=url.port)
 
 
-def run_openstack_tests(dockerhub_mirror: str | None, ssh_connection: SSHConnection):
+def run_openstack_tests(
+    dockerhub_mirror: str | None, ssh_connection: SSHConnection, external: bool = False
+):
     """Run test commands on the openstack instance via ssh.
 
     Args:
         dockerhub_mirror: The dockerhub mirror URL to reduce rate limiting for tests.
         ssh_connection: The SSH connection instance to OpenStack test server.
+        external: Whether the test is for external VM builder image test.
     """
     for testcmd in commands.TEST_RUNNER_COMMANDS:
+        if not external and testcmd.external:
+            continue
         if testcmd == "configure dockerhub mirror":
             if not dockerhub_mirror:
                 continue

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -133,6 +133,8 @@ async def test_image_amd(image: str, tmp_path: Path, dockerhub_mirror: str | Non
     instance = await helpers.create_lxd_instance(lxd_client=lxd, image=image)
 
     for testcmd in commands.TEST_RUNNER_COMMANDS:
+        if testcmd.external:
+            continue
         if testcmd == "configure dockerhub mirror":
             if not dockerhub_mirror:
                 continue

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -190,7 +190,9 @@ async def test_run(ssh_connection: SSHConnection, dockerhub_mirror: str | None):
     act: when run (build image) is called.
     assert: an image snapshot of working VM is created with the ability to run expected commands.
     """
-    helpers.run_openstack_tests(dockerhub_mirror=dockerhub_mirror, ssh_connection=ssh_connection)
+    helpers.run_openstack_tests(
+        dockerhub_mirror=dockerhub_mirror, ssh_connection=ssh_connection, external=True
+    )
 
 
 @pytest.mark.amd64

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -101,6 +101,7 @@ def cli_run_fixture(
             base=config.BaseImage.from_str(image_config.image),
             runner_version="",
             name=f"{test_id}-image-builder-test",
+            juju="3.1/stable",
         ),
         keep_revisions=1,
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -40,6 +40,7 @@ def run_inputs_fixture(callback_path: Path):
         "--base-image": "noble",
         "--keep-revisions": "5",
         "--callback-script": str(callback_path),
+        "--juju": "3.1/stable",
     }
 
 
@@ -175,6 +176,7 @@ def test_latest_build_id(monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner)
         ),
         pytest.param({"": ""}, id="empty cloud name positional argument"),
         pytest.param({" ": ""}, id="empty image name positional argument"),
+        pytest.param({"--juju": "invalid-value"}, id="invalid juju channel value"),
     ],
 )
 def test_invalid_run_args(cli_runner: CliRunner, run_inputs: dict, invalid_args: dict):

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -683,6 +683,9 @@ function install_juju() {
         echo "Juju channel not provided, skipping installation."
         return
     fi
+    if ! lxd --version &> /dev/null; then
+        /usr/bin/snap install lxd
+    fi
     /snap/bin/lxd init --auto
     /usr/bin/snap install juju --channel="$channel"
     /usr/bin/sudo -E -H -u ubuntu /snap/bin/juju bootstrap localhost localhost

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -683,9 +683,9 @@ function install_juju() {
         echo "Juju channel not provided, skipping installation."
         return
     fi
-    /usr/bin/sudo -E /snap/bin/lxd init --auto
-    /usr/bin/sudo -E /usr/bin/snap install juju --channel="$channel"
-    /snap/bin/juju bootstrap localhost localhost
+    /snap/bin/lxd init --auto
+    /usr/bin/snap install juju --channel="$channel"
+    /usr/bin/sudo -E -H -u ubuntu /snap/bin/juju bootstrap localhost localhost
 }
 
 function install_github_runner() {


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Installs juju and bootstraps local LXD

### Rationale

- To provide images with juju already installed & bootstrapped.

### Module Changes

- cli.py - adds juju cli option
- openstack_builder.py - passes juju channel info to cloud-init template
- cloud-init.sh.j2 - adds a function to install and bootstrap juju if defined.

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
