### PR TITLE
fix: lengthen cloud-init timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -528,7 +528,7 @@ def _wait_for_cloud_init_complete(
     ssh_connection = _get_ssh_connection(conn=conn, server=server, ssh_key=ssh_key)
     try:
         result: fabric.Result | None = ssh_connection.run(
-            "cloud-init status --wait", timeout=60 * 10
+            "cloud-init status --wait", timeout=60 * 30
         )
     except invoke.exceptions.UnexpectedExit as exc:
         log_out = conn.get_server_console(server=server)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Lengthen timeout for cloud-init wait

### Rationale

Depending on network conditions, juju & microk8s takes longer.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
