### PR TITLE
feat: support dockerhub cache during installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/openstack_builder.md
+++ b/src-docs/openstack_builder.md
@@ -70,7 +70,7 @@ Upload ubuntu base images to openstack to use as builder base. This is a separat
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L236"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -110,6 +110,7 @@ The OpenStack cloud configuration values.
 **Attributes:**
  
  - <b>`cloud_name`</b>:  The OpenStack cloud name to use. 
+ - <b>`dockerhub_cache`</b>:  The DockerHub cache to use for using cached images. 
  - <b>`flavor`</b>:  The OpenStack flavor to launch builder VMs on. 
  - <b>`network`</b>:  The OpenStack network to launch the builder VMs on. 
  - <b>`prefix`</b>:  The prefix to use for OpenStack resource names. 
@@ -123,6 +124,7 @@ The OpenStack cloud configuration values.
 ```python
 __init__(
     cloud_name: str,
+    dockerhub_cache: str,
     flavor: str,
     network: str,
     prefix: str,

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -137,6 +137,15 @@ def _validate_snap_channel(
     help=("The Ubuntu base image to use as build base."),
 )
 @click.option(
+    "--dockerhub-cache",
+    type=str,
+    default="",
+    help=(
+        "The DockerHub cache to use to instantiate builder VMs with. Useful when creating images"
+        "with MicroK8s."
+    ),
+)
+@click.option(
     "-k",
     "--keep-revisions",
     default=5,
@@ -215,6 +224,7 @@ def _validate_snap_channel(
 def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positional-arguments
     arch: config.Arch | None,
     cloud_name: str,
+    dockerhub_cache: str,
     image_name: str,
     base_image: str,
     keep_revisions: int,
@@ -235,6 +245,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
         arch: The architecture to run build for.
         cloud_name: The cloud to use from the clouds.yaml file. The CLI looks for clouds.yaml in
             paths of the following order: current directory, ~/.config/openstack, /etc/openstack.
+        dockerhub_cache: The DockerHub cache to use for using cached images.
         image_name: The image name uploaded to Openstack.
         base_image: The Ubuntu base image to use as build base.
         keep_revisions: Number of past revisions to keep before deletion.
@@ -277,6 +288,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
         image_ids = openstack_builder.run(
             cloud_config=openstack_builder.CloudConfig(
                 cloud_name=cloud_name,
+                dockerhub_cache=dockerhub_cache,
                 flavor=flavor,
                 network=network,
                 prefix=prefix,

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -215,6 +215,7 @@ class CloudConfig:
 
     Attributes:
         cloud_name: The OpenStack cloud name to use.
+        dockerhub_cache: The DockerHub cache to use for using cached images.
         flavor: The OpenStack flavor to launch builder VMs on.
         network: The OpenStack network to launch the builder VMs on.
         prefix: The prefix to use for OpenStack resource names.
@@ -224,6 +225,7 @@ class CloudConfig:
     """
 
     cloud_name: str
+    dockerhub_cache: str
     flavor: str
     network: str
     prefix: str
@@ -249,6 +251,7 @@ def run(
     cloud_init_script = _generate_cloud_init_script(
         image_config=image_config,
         proxy=cloud_config.proxy,
+        dockerhub_cache=cloud_config.dockerhub_cache,
     )
     builder_name = _get_builder_name(
         arch=image_config.arch, base=image_config.base, prefix=cloud_config.prefix
@@ -461,12 +464,14 @@ def _determine_network(conn: openstack.connection.Connection, network_name: str 
 def _generate_cloud_init_script(
     image_config: config.ImageConfig,
     proxy: str,
+    dockerhub_cache: str,
 ) -> str:
     """Generate userdata for installing GitHub runner image components.
 
     Args:
         image_config: The target image configuration values.
         proxy: The proxy to enable while setting up the VM.
+        dockerhub_cache: The DockerHub cache to use for using cached images.
 
     Returns:
         The cloud-init script to create snapshot image.
@@ -478,6 +483,7 @@ def _generate_cloud_init_script(
     template = env.get_template("cloud-init.sh.j2")
     return template.render(
         PROXY_URL=proxy,
+        DOCKERHUB_CACHE=dockerhub_cache,
         APT_PACKAGES=" ".join(IMAGE_DEFAULT_APT_PACKAGES),
         HWE_VERSION=BaseImage.get_version(image_config.base),
         MICROK8S_CHANNEL=image_config.microk8s,

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -33,6 +33,15 @@ EOF
     sleep 5
 }
 
+function configure_dockerhub_cache() {
+    local dockerhub_cache="$1"
+    if [[ -z "$dockerhub_cache" ]]; then
+        echo "Dockerhub cache not configured, skipping..."
+        return
+    fi
+    sudo mkdir -p /etc/docker/ && echo { \"registry-mirrors\": [\"$dockerhub_cache\"]}} | sudo tee /etc/docker/daemon.json
+}
+
 function install_apt_packages() {
     local packages="$1"
     local hwe_version="$2"
@@ -155,6 +164,7 @@ function chown_home() {
 }
 
 proxy="{{ PROXY_URL }}"
+dockerhub_cache="{{ DOCKERHUB_CACHE }}"
 apt_packages="{{ APT_PACKAGES }}"
 hwe_version="{{ HWE_VERSION }}"
 github_runner_version="{{ RUNNER_VERSION }}"
@@ -163,6 +173,7 @@ microk8s_channel="{{ MICROK8S_CHANNEL }}"
 juju_channel="{{ JUJU_CHANNEL }}"
 
 configure_proxy "$proxy"
+configure_dockerhub_cache "$dockerhub_cache"
 install_apt_packages "$apt_packages" "$hwe_version"
 disable_unattended_upgrades
 enable_network_fair_queuing_congestion

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -206,7 +206,7 @@ echo $IMAGE_ID | tee {callback_result_path}
 @pytest.fixture(scope="module", name="dockerhub_mirror")
 def dockerhub_mirror_fixture(pytestconfig: pytest.Config) -> str | None:
     """Dockerhub mirror URL."""
-    return pytestconfig.getoption("--dockerhub-mirror")
+    return pytestconfig.getoption("--dockerhub-mirror", default="")
 
 
 @pytest.fixture(scope="module", name="openstack_image_name")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -251,7 +251,6 @@ async def wait_for_valid_connection(
     connection_params: OpenStackConnectionParams,
     timeout: int = 30 * 60,
     proxy: types.ProxyConfig | None = None,
-    dockerhub_mirror: str | None = None,
 ) -> SSHConnection:
     """Wait for a valid SSH connection from Openstack server.
 
@@ -259,7 +258,6 @@ async def wait_for_valid_connection(
         connection_params: Parameters for connecting to OpenStack instance.
         timeout: Number of seconds to wait before raising a timeout error.
         proxy: The proxy to configure on host runner.
-        dockerhub_mirror: The DockerHub mirror URL.
 
     Raises:
         TimeoutError: If no valid connections were found.
@@ -292,9 +290,6 @@ async def wait_for_valid_connection(
                 result: Result = ssh_connection.run("echo 'hello world'")
                 if result.ok:
                     await _install_proxy(conn=ssh_connection, proxy=proxy)
-                    _configure_dockerhub_mirror(
-                        conn=ssh_connection, dockerhub_mirror=dockerhub_mirror
-                    )
                     return ssh_connection
             except (NoValidConnectionsError, TimeoutError, SSHException) as exc:
                 logger.warning("Connection not yet ready, %s.", str(exc))
@@ -365,67 +360,16 @@ def _snap_ready(conn: SSHConnection) -> bool:
         return False
 
 
-@tenacity.retry(
-    wait=tenacity.wait_exponential(multiplier=2, min=10, max=60),
-    stop=tenacity.stop_after_attempt(10),
-)
-def _configure_dockerhub_mirror(conn: SSHConnection, dockerhub_mirror: str | None):
-    """Use dockerhub mirror if provided.
-
-    Args:
-        conn: The SSH connection instance.
-        dockerhub_mirror: The DockerHub mirror URL.
-    """
-    if not dockerhub_mirror:
-        return
-    command = f'sudo mkdir -p /etc/docker/ && \
-echo {{ \\"registry-mirrors\\": [\\"{dockerhub_mirror}\\"]}} | sudo tee /etc/docker/daemon.json'
-    logger.info("Running command: %s", command)
-    result: Result = conn.run(command)
-    assert result.ok, "Failed to setup DockerHub mirror"
-
-    command = "sudo systemctl daemon-reload"
-    result = conn.run(command)
-    assert result.ok, "Failed to reload daemon"
-
-    command = "sudo systemctl restart docker"
-    result = conn.run(command)
-    assert result.ok, "Failed to restart docker"
-
-
-def format_dockerhub_mirror_microk8s_command(command: str, dockerhub_mirror: str) -> str:
-    """Format dockerhub mirror for microk8s command.
-
-    Args:
-        command: The command to run.
-        dockerhub_mirror: The DockerHub mirror URL.
-
-    Returns:
-        The formatted dockerhub mirror registry command for snap microk8s.
-    """
-    url = urllib.parse.urlparse(dockerhub_mirror)
-    return command.format(registry_url=url.geturl(), hostname=url.hostname, port=url.port)
-
-
-def run_openstack_tests(
-    dockerhub_mirror: str | None, ssh_connection: SSHConnection, external: bool = False
-):
+def run_openstack_tests(ssh_connection: SSHConnection, external: bool = False):
     """Run test commands on the openstack instance via ssh.
 
     Args:
-        dockerhub_mirror: The dockerhub mirror URL to reduce rate limiting for tests.
         ssh_connection: The SSH connection instance to OpenStack test server.
         external: Whether the test is for external VM builder image test.
     """
     for testcmd in commands.TEST_RUNNER_COMMANDS:
         if not external and testcmd.external:
             continue
-        if testcmd == "configure dockerhub mirror":
-            if not dockerhub_mirror:
-                continue
-            testcmd.command = format_dockerhub_mirror_microk8s_command(
-                command=testcmd.command, dockerhub_mirror=dockerhub_mirror
-            )
         logger.info("Running command: %s", testcmd.command)
         result: Result = ssh_connection.run(testcmd.command, env=testcmd.env)
         logger.info("Command output: %s %s %s", result.return_code, result.stdout, result.stderr)

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -52,10 +52,7 @@ async def openstack_server_fixture(
 
 @pytest_asyncio.fixture(scope="module", name="ssh_connection")
 async def ssh_connection_fixture(
-    openstack_server: Server,
-    proxy: types.ProxyConfig,
-    openstack_metadata: types.OpenstackMeta,
-    dockerhub_mirror: str | None,
+    openstack_server: Server, proxy: types.ProxyConfig, openstack_metadata: types.OpenstackMeta
 ) -> SSHConnection:
     """The openstack server ssh connection fixture."""
     logger.info("Setting up SSH connection.")
@@ -67,7 +64,6 @@ async def ssh_connection_fixture(
             ssh_key=openstack_metadata.ssh_key.private_key,
         ),
         proxy=proxy,
-        dockerhub_mirror=dockerhub_mirror,
     )
 
     return ssh_connection
@@ -118,7 +114,7 @@ def cli_run_fixture(
 @pytest.mark.asyncio
 @pytest.mark.amd64
 @pytest.mark.usefixtures("cli_run")
-async def test_image_amd(image: str, tmp_path: Path, dockerhub_mirror: str | None):
+async def test_image_amd(image: str, tmp_path: Path):
     """
     arrange: given a built output from the CLI.
     act: when the image is booted and commands are executed.
@@ -135,12 +131,6 @@ async def test_image_amd(image: str, tmp_path: Path, dockerhub_mirror: str | Non
     for testcmd in commands.TEST_RUNNER_COMMANDS:
         if testcmd.external:
             continue
-        if testcmd == "configure dockerhub mirror":
-            if not dockerhub_mirror:
-                continue
-            testcmd.command = helpers.format_dockerhub_mirror_microk8s_command(
-                command=testcmd.command, dockerhub_mirror=dockerhub_mirror
-            )
         logger.info("Running command: %s", testcmd.command)
         # run command as ubuntu user. Passing in user argument would not be equivalent to a login
         # shell which is missing critical environment variables such as $USER and the user groups
@@ -168,13 +158,13 @@ async def test_openstack_upload(openstack_connection: Connection, openstack_imag
 @pytest.mark.arm64
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("cli_run")
-async def test_image_arm(ssh_connection: SSHConnection, dockerhub_mirror: str | None):
+async def test_image_arm(ssh_connection: SSHConnection):
     """
     arrange: given a built output from the CLI.
     act: when the image is booted and commands are executed.
     assert: commands do not error.
     """
-    helpers.run_openstack_tests(dockerhub_mirror=dockerhub_mirror, ssh_connection=ssh_connection)
+    helpers.run_openstack_tests(ssh_connection=ssh_connection)
 
 
 @pytest.mark.amd64

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -81,6 +81,7 @@ def image_ids_fixture(
     openstack_metadata: types.OpenstackMeta,
     test_id: str,
     proxy: types.ProxyConfig,
+    dockerhub_mirror: str,
 ):
     """A CLI run.
 
@@ -90,6 +91,7 @@ def image_ids_fixture(
     image_ids = openstack_builder.run(
         cloud_config=openstack_builder.CloudConfig(
             cloud_name=openstack_metadata.cloud_name,
+            dockerhub_cache=dockerhub_mirror,
             flavor=openstack_metadata.flavor,
             network=openstack_metadata.network,
             proxy=proxy.http,
@@ -158,10 +160,7 @@ async def openstack_server_fixture(
 
 @pytest_asyncio.fixture(scope="module", name="ssh_connection")
 async def ssh_connection_fixture(
-    openstack_server: Server,
-    proxy: types.ProxyConfig,
-    openstack_metadata: types.OpenstackMeta,
-    dockerhub_mirror: str | None,
+    openstack_server: Server, proxy: types.ProxyConfig, openstack_metadata: types.OpenstackMeta
 ) -> SSHConnection:
     """The openstack server ssh connection fixture."""
     logger.info("Setting up SSH connection.")
@@ -173,7 +172,6 @@ async def ssh_connection_fixture(
             ssh_key=openstack_metadata.ssh_key.private_key,
         ),
         proxy=proxy,
-        dockerhub_mirror=dockerhub_mirror,
     )
 
     return ssh_connection
@@ -185,15 +183,13 @@ async def ssh_connection_fixture(
 @pytest.mark.amd64
 @pytest.mark.arm64
 @pytest.mark.usefixtures("make_dangling_resources")
-async def test_run(ssh_connection: SSHConnection, dockerhub_mirror: str | None):
+async def test_run(ssh_connection: SSHConnection):
     """
     arrange: given openstack cloud instance.
     act: when run (build image) is called.
     assert: an image snapshot of working VM is created with the ability to run expected commands.
     """
-    helpers.run_openstack_tests(
-        dockerhub_mirror=dockerhub_mirror, ssh_connection=ssh_connection, external=True
-    )
+    helpers.run_openstack_tests(ssh_connection=ssh_connection, external=True)
 
 
 @pytest.mark.amd64

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -172,6 +172,7 @@ def test__create_security_group():
         pytest.param(
             openstack_builder.CloudConfig(
                 cloud_name="test-cloud",
+                dockerhub_cache="https://test-dockerhub-cache.com:5000",
                 flavor="test-flavor",
                 network="test-network",
                 prefix="",
@@ -183,6 +184,7 @@ def test__create_security_group():
         pytest.param(
             openstack_builder.CloudConfig(
                 cloud_name="test-cloud",
+                dockerhub_cache="https://test-dockerhub-cache.com:5000",
                 flavor="test-flavor",
                 network="test-network",
                 prefix="",
@@ -194,6 +196,7 @@ def test__create_security_group():
         pytest.param(
             openstack_builder.CloudConfig(
                 cloud_name="test-cloud",
+                dockerhub_cache="https://test-dockerhub-cache.com:5000",
                 flavor="test-flavor",
                 network="test-network",
                 prefix="",
@@ -582,6 +585,7 @@ def test__generate_cloud_init_script():
                 name="test-image",
             ),
             proxy="test.proxy.internal:3128",
+            dockerhub_cache="https://test-dockerhub-cache.com:5000",
         )
         # The templated script contains similar lines to helper for setting up proxy.
         # pylint: disable=R0801
@@ -619,6 +623,16 @@ EOF
     /usr/bin/sudo snap set aproxy proxy=${proxy} listen=:8444;
     echo "Wait for aproxy to start"
     sleep 5
+}
+
+function configure_dockerhub_cache() {
+    local dockerhub_cache="$1"
+    if [[ -z "$dockerhub_cache" ]]; then
+        echo "Dockerhub cache not configured, skipping..."
+        return
+    fi
+    sudo mkdir -p /etc/docker/ && echo { \\"registry-mirrors\\": [\\"$dockerhub_cache\\"]}} | sudo tee \
+/etc/docker/daemon.json
 }
 
 function install_apt_packages() {
@@ -747,6 +761,7 @@ function chown_home() {
 }
 
 proxy="test.proxy.internal:3128"
+dockerhub_cache="https://test-dockerhub-cache.com:5000"
 apt_packages="build-essential docker.io gh jq npm python3-dev python3-pip python-is-python3 \
 shellcheck tar time unzip wget"
 hwe_version="22.04"
@@ -756,6 +771,7 @@ microk8s_channel="1.29-strict/stable"
 juju_channel="3.1/stable"
 
 configure_proxy "$proxy"
+configure_dockerhub_cache "$dockerhub_cache"
 install_apt_packages "$apt_packages" "$hwe_version"
 disable_unattended_upgrades
 enable_network_fair_queuing_congestion


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Use dockerhub cache during cloud-init install

### Rationale

- To prevent dockerhub rate limiting impacting microk8s setup

### Module Changes

- `cli.py` now parses dockerhub cache argument

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
