### PR TITLE
feat: external script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src-docs/config.md
+++ b/src-docs/config.md
@@ -16,7 +16,7 @@ Module containing configurations.
 
 ---
 
-<a href="../src/github_runner_image_builder/config.py#L46"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/config.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_supported_arch`
 
@@ -41,7 +41,7 @@ Get current machine architecture.
 
 ---
 
-<a href="../src/github_runner_image_builder/config.py#L17"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/config.py#L18"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `Arch`
 Supported system architectures. 
@@ -59,7 +59,7 @@ Supported system architectures.
 
 ---
 
-<a href="../src/github_runner_image_builder/config.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/config.py#L66"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `BaseImage`
 The ubuntu OS base image to build and deploy runners on. 
@@ -77,7 +77,7 @@ The ubuntu OS base image to build and deploy runners on.
 
 ---
 
-<a href="../src/github_runner_image_builder/config.py#L140"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/config.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ImageConfig`
 The build image configuration values. 
@@ -91,6 +91,7 @@ The build image configuration values.
  - <b>`microk8s`</b>:  The MicroK8s snap channel to install. 
  - <b>`juju`</b>:  The Juju channel to install and bootstrap. 
  - <b>`runner_version`</b>:  The GitHub runner version to install on the VM. Defaults to latest. 
+ - <b>`script_url`</b>:  The external setup bash script URL. 
  - <b>`name`</b>:  The image name to upload on OpenStack. 
 
 <a href="../<string>"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
@@ -104,6 +105,7 @@ __init__(
     microk8s: str,
     juju: str,
     runner_version: str,
+    script_url: ParseResult | None,
     name: str
 ) → None
 ```

--- a/src-docs/openstack_builder.md
+++ b/src-docs/openstack_builder.md
@@ -17,7 +17,7 @@ Module for interacting with external openstack VM image builder.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L61"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `determine_cloud`
 
@@ -47,7 +47,7 @@ Automatically determine cloud to use from clouds.yaml by selecting the first clo
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `initialize`
 
@@ -70,7 +70,7 @@ Upload ubuntu base images to openstack to use as builder base. This is a separat
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L236"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L238"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `run`
 
@@ -100,7 +100,7 @@ Run external OpenStack builder instance and create a snapshot.
 
 ---
 
-<a href="../src/github_runner_image_builder/openstack_builder.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/openstack_builder.py#L214"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `CloudConfig`
 The OpenStack cloud configuration values. 
@@ -124,7 +124,7 @@ The OpenStack cloud configuration values.
 ```python
 __init__(
     cloud_name: str,
-    dockerhub_cache: str,
+    dockerhub_cache: ParseResult | None,
     flavor: str,
     network: str,
     prefix: str,

--- a/src-docs/store.md
+++ b/src-docs/store.md
@@ -46,7 +46,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `upload_image`
 
@@ -86,7 +86,7 @@ Upload image to openstack glance.
 
 ---
 
-<a href="../src/github_runner_image_builder/store.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_runner_image_builder/store.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_latest_build_id`
 

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -299,6 +299,9 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
     arch = arch if arch else config.get_supported_arch()
     base = config.BaseImage.from_str(base_image)
     if not experimental_external:
+        click.echo(
+            "[WARNING] Image builder via chroot will be deprecated in version 0.9.0.", err=True
+        )
         image_ids = builder.run(
             cloud_name=cloud_name,
             image_config=config.ImageConfig(

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -130,19 +130,19 @@ def _parse_url(
     Args:
         ctx: Click context argument.
         param: Click parameter argument.
-        value: The value passed into --dockerhub-cache option.
+        value: The value passed into any URL option.
 
     Raises:
         BadParameter: If invalid URL was passed in.
 
     Returns:
-        The dockerhub cache URL.
+        The valid URL parse result.
     """
     if not value:
         return None
     parse_result = urllib.parse.urlparse(value)
-    if not parse_result.netloc or not parse_result.scheme or not parse_result.port:
-        raise click.BadParameter("URL must be '<scheme>://<hostname>:<port>' format")
+    if not parse_result.netloc or not parse_result.scheme:
+        raise click.BadParameter("URL must be '<scheme>://<hostname>' format")
     return parse_result
 
 
@@ -242,7 +242,8 @@ def _parse_url(
 )
 @click.option(
     "--script-url",
-    default="",
+    callback=_parse_url,
+    default=None,
     help="Run an external bash setup script fetched from the URL on the runners during cloud-init."
     "Installation is run as root within the cloud-init script after the bare image default setup.",
 )
@@ -270,7 +271,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
     network: str,
     prefix: str,
     proxy: str,
-    script_url: str,
+    script_url: urllib.parse.ParseResult | None,
     upload_clouds: str,
 ) -> None:
     """Build a cloud image using chroot and upload it to OpenStack.
@@ -306,6 +307,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
                 microk8s=microk8s,
                 juju=juju,
                 runner_version=runner_version,
+                script_url=None,
                 name=image_name,
             ),
             keep_revisions=keep_revisions,
@@ -336,6 +338,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
                 microk8s=microk8s,
                 juju=juju,
                 runner_version=runner_version,
+                script_url=script_url,
                 name=image_name,
             ),
             keep_revisions=keep_revisions,

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -173,12 +173,6 @@ def _parse_url(
     ),
 )
 @click.option(
-    "-k",
-    "--keep-revisions",
-    default=5,
-    help="The maximum number of images to keep before deletion.",
-)
-@click.option(
     "-s",
     "--callback-script",
     type=click.Path(exists=True),
@@ -187,6 +181,12 @@ def _parse_url(
         "The callback script to trigger after image is built. The callback script is called"
         "with the first argument as the image ID."
     ),
+)
+@click.option(
+    "-k",
+    "--keep-revisions",
+    default=5,
+    help="The maximum number of images to keep before deletion.",
 )
 @click.option(
     "--runner-version",
@@ -241,6 +241,12 @@ def _parse_url(
     "Ignored if --experimental-external is not enabled",
 )
 @click.option(
+    "--script-url",
+    default="",
+    help="Run an external bash setup script fetched from the URL on the runners during cloud-init."
+    "Installation is run as root within the cloud-init script after the bare image default setup.",
+)
+@click.option(
     "--upload-clouds",
     default="",
     help="EXPERIMENTAL: Comma separated list of different clouds to use to upload the externally "
@@ -264,6 +270,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
     network: str,
     prefix: str,
     proxy: str,
+    script_url: str,
     upload_clouds: str,
 ) -> None:
     """Build a cloud image using chroot and upload it to OpenStack.
@@ -285,6 +292,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
         network: The Openstack network to assign to server to build images.
         prefix: The prefix to use for OpenStack resource names.
         proxy: Proxy to use for external build VMs.
+        script_url: The external setup bash script URL.
         upload_clouds: The Openstack cloud to use to upload externally built image.
     """
     arch = arch if arch else config.get_supported_arch()

--- a/src/github_runner_image_builder/config.py
+++ b/src/github_runner_image_builder/config.py
@@ -7,6 +7,7 @@ import dataclasses
 import itertools
 import logging
 import platform
+import urllib.parse
 from enum import Enum
 from pathlib import Path
 from typing import Literal
@@ -147,6 +148,7 @@ class ImageConfig:
         microk8s: The MicroK8s snap channel to install.
         juju: The Juju channel to install and bootstrap.
         runner_version: The GitHub runner version to install on the VM. Defaults to latest.
+        script_url: The external setup bash script URL.
         name: The image name to upload on OpenStack.
     """
 
@@ -155,4 +157,5 @@ class ImageConfig:
     microk8s: str
     juju: str
     runner_version: str
+    script_url: urllib.parse.ParseResult | None
     name: str

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -494,7 +494,7 @@ def _generate_cloud_init_script(
         JUJU_CHANNEL=image_config.juju,
         RUNNER_VERSION=image_config.runner_version,
         RUNNER_ARCH=image_config.arch.value,
-        SCRIPT_URL=image_config.script_url if image_config.script_url else "",
+        SCRIPT_URL=image_config.script_url.geturl() if image_config.script_url else "",
     )
 
 

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -494,6 +494,7 @@ def _generate_cloud_init_script(
         JUJU_CHANNEL=image_config.juju,
         RUNNER_VERSION=image_config.runner_version,
         RUNNER_ARCH=image_config.arch.value,
+        SCRIPT_URL=image_config.script_url if image_config.script_url else "",
     )
 
 

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -184,6 +184,18 @@ function configure_system_users() {
     /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
 }
 
+function execute_script() {
+    local script_url="$1"
+    if [[ -z "$script_url" ]]; then
+        echo "Script URL not provided, skipping."
+        return
+    fi
+    wget "$script_url" -O external.sh
+    chmod +x external.sh
+    ./external.sh
+    rm external.sh
+}
+
 proxy="{{ PROXY_URL }}"
 dockerhub_cache_url="{{ DOCKERHUB_CACHE_URL }}"
 dockerhub_cache_host="{{ DOCKERHUB_CACHE_HOST }}"
@@ -210,7 +222,7 @@ chown_home
 install_microk8s "$microk8s_channel" "$dockerhub_cache_url" "$dockerhub_cache_host" "$dockerhub_cache_port"
 install_juju "$juju_channel"
 configure_system_users
-
+execute_script "$script_url"
 
 # Make sure the disk is synced for snapshot
 sync

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -61,17 +61,6 @@ EOF
     /usr/sbin/sysctl -p
 }
 
-function configure_system_users() {
-    echo "Configuring ubuntu user"
-    # only add ubuntu user if ubuntu does not exist
-    /usr/bin/id -u ubuntu &>/dev/null || useradd --create-home ubuntu
-    echo "PATH=\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.profile
-    echo "PATH=\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.bashrc
-    /usr/sbin/groupadd -f microk8s
-    /usr/sbin/groupadd -f docker
-    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
-}
-
 function configure_usr_local_bin() {
     echo "Configuring /usr/local/bin path"
     /usr/bin/chmod 777 /usr/local/bin
@@ -90,6 +79,29 @@ function install_yq() {
     /usr/bin/sudo -E /snap/bin/go build -C yq -o /usr/bin/yq
     /usr/bin/sudo -E /usr/bin/rm -rf yq
     /usr/bin/sudo -E /usr/bin/snap remove go
+}
+
+function install_github_runner() {
+    version="$1"
+    arch="$2"
+    echo "Installing GitHub runner"
+    if [[ -z "$version" ]]; then
+        # Follow redirectin to get latest version release location
+        # e.g. https://github.com/actions/runner/releases/tag/v2.318.0
+        location=$(curl -sIL "https://github.com/actions/runner/releases/latest" | sed -n 's/^location: *//p' | tr -d '[:space:]')
+        # remove longest prefix from the right that matches the pattern */v
+        # e.g. 2.318.0
+        version=${location##*/v}
+    fi
+    /usr/bin/wget "https://github.com/actions/runner/releases/download/v$version/actions-runner-linux-$arch-$version.tar.gz"
+    /usr/bin/mkdir -p /home/ubuntu/actions-runner
+    /usr/bin/tar -xvzf "actions-runner-linux-$arch-$version.tar.gz" --directory /home/ubuntu/actions-runner
+
+    rm "actions-runner-linux-$arch-$version.tar.gz"
+}
+
+function chown_home() {
+    /usr/bin/chown --recursive ubuntu:ubuntu /home/ubuntu/
 }
 
 function install_microk8s() {
@@ -161,27 +173,15 @@ function install_juju() {
     fi
 }
 
-function install_github_runner() {
-    version="$1"
-    arch="$2"
-    echo "Installing GitHub runner"
-    if [[ -z "$version" ]]; then
-        # Follow redirectin to get latest version release location
-        # e.g. https://github.com/actions/runner/releases/tag/v2.318.0
-        location=$(curl -sIL "https://github.com/actions/runner/releases/latest" | sed -n 's/^location: *//p' | tr -d '[:space:]')
-        # remove longest prefix from the right that matches the pattern */v
-        # e.g. 2.318.0
-        version=${location##*/v}
-    fi
-    /usr/bin/wget "https://github.com/actions/runner/releases/download/v$version/actions-runner-linux-$arch-$version.tar.gz"
-    /usr/bin/mkdir -p /home/ubuntu/actions-runner
-    /usr/bin/tar -xvzf "actions-runner-linux-$arch-$version.tar.gz" --directory /home/ubuntu/actions-runner
-
-    rm "actions-runner-linux-$arch-$version.tar.gz"
-}
-
-function chown_home() {
-    /usr/bin/chown --recursive ubuntu:ubuntu /home/ubuntu/
+function configure_system_users() {
+    echo "Configuring ubuntu user"
+    # only add ubuntu user if ubuntu does not exist
+    /usr/bin/id -u ubuntu &>/dev/null || useradd --create-home ubuntu
+    echo "PATH=\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.profile
+    echo "PATH=\$PATH:/home/ubuntu/.local/bin" >> /home/ubuntu/.bashrc
+    /usr/sbin/groupadd -f microk8s
+    /usr/sbin/groupadd -f docker
+    /usr/sbin/usermod --append --groups docker,microk8s,lxd,sudo ubuntu
 }
 
 proxy="{{ PROXY_URL }}"
@@ -194,6 +194,7 @@ github_runner_version="{{ RUNNER_VERSION }}"
 github_runner_arch="{{ RUNNER_ARCH }}"
 microk8s_channel="{{ MICROK8S_CHANNEL }}"
 juju_channel="{{ JUJU_CHANNEL }}"
+script_url="{{ SCRIPT_URL }}"
 
 configure_proxy "$proxy"
 install_apt_packages "$apt_packages" "$hwe_version"
@@ -209,6 +210,8 @@ chown_home
 install_microk8s "$microk8s_channel" "$dockerhub_cache_url" "$dockerhub_cache_host" "$dockerhub_cache_port"
 install_juju "$juju_channel"
 configure_system_users
+
+
 # Make sure the disk is synced for snapshot
 sync
 echo "Finished sync"

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -85,4 +85,9 @@ sudo microk8s stop && sudo microk8s start""",
         command="sudo sysctl -a | grep 'net.ipv4.tcp_congestion_control = bbr'",
     ),
     Commands(name="test juju installed", command="juju version | grep 3.1", external=True),
+    Commands(
+        name="test external script",
+        command="cat /home/ubuntu/test.txt | grep 'hello world'",
+        external=True,
+    ),
 )

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -138,7 +138,7 @@ async def test_image_amd(
     for testcmd in commands.TEST_RUNNER_COMMANDS:
         if testcmd.external:
             continue
-        if testcmd == "configure dockerhub mirror":
+        if testcmd.name == "configure dockerhub mirror":
             if not dockerhub_mirror:
                 continue
             testcmd.command = helpers.format_dockerhub_mirror_microk8s_command(

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -106,6 +106,11 @@ def image_ids_fixture(
             runner_version="",
             name=f"{test_id}-image-builder-test",
             juju="3.1/stable",
+            script_url=urllib.parse.urlparse(
+                "https://raw.githubusercontent.com/canonical/github-runner-image-builder/"
+                "eb0ca315bf8c7aa732b811120cbabca4b8d16216/tests/integration/testdata/"
+                "test_script.sh"
+            ),
         ),
         keep_revisions=1,
     )

--- a/tests/integration/testdata/test_script.sh
+++ b/tests/integration/testdata/test_script.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo -H -u ubuntu bash -c 'echo "hello world" > /home/ubuntu/test.txt'

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -686,6 +686,32 @@ function install_yq() {
     /usr/bin/sudo -E /usr/bin/snap remove go
 }
 
+function install_github_runner() {
+    version="$1"
+    arch="$2"
+    echo "Installing GitHub runner"
+    if [[ -z "$version" ]]; then
+        # Follow redirectin to get latest version release location
+        # e.g. https://github.com/actions/runner/releases/tag/v2.318.0
+        location=$(curl -sIL "https://github.com/actions/runner/releases/latest" | sed -n \
+'s/^location: *//p' | tr -d '[:space:]')
+        # remove longest prefix from the right that matches the pattern */v
+        # e.g. 2.318.0
+        version=${location##*/v}
+    fi
+    /usr/bin/wget "https://github.com/actions/runner/releases/download/v$version/\
+actions-runner-linux-$arch-$version.tar.gz"
+    /usr/bin/mkdir -p /home/ubuntu/actions-runner
+    /usr/bin/tar -xvzf "actions-runner-linux-$arch-$version.tar.gz" --directory \
+/home/ubuntu/actions-runner
+
+    rm "actions-runner-linux-$arch-$version.tar.gz"
+}
+
+function chown_home() {
+    /usr/bin/chown --recursive ubuntu:ubuntu /home/ubuntu/
+}
+
 function install_microk8s() {
     local channel="$1"
     local dockerhub_cache_url="$2"
@@ -753,32 +779,6 @@ function install_juju() {
         echo "Bootstrapping MicroK8s on Juju"
         /usr/bin/sudo -E -H -u ubuntu /snap/bin/juju bootstrap microk8s microk8s
     fi
-}
-
-function install_github_runner() {
-    version="$1"
-    arch="$2"
-    echo "Installing GitHub runner"
-    if [[ -z "$version" ]]; then
-        # Follow redirectin to get latest version release location
-        # e.g. https://github.com/actions/runner/releases/tag/v2.318.0
-        location=$(curl -sIL "https://github.com/actions/runner/releases/latest" | sed -n \
-'s/^location: *//p' | tr -d '[:space:]')
-        # remove longest prefix from the right that matches the pattern */v
-        # e.g. 2.318.0
-        version=${location##*/v}
-    fi
-    /usr/bin/wget "https://github.com/actions/runner/releases/download/v$version/\
-actions-runner-linux-$arch-$version.tar.gz"
-    /usr/bin/mkdir -p /home/ubuntu/actions-runner
-    /usr/bin/tar -xvzf "actions-runner-linux-$arch-$version.tar.gz" --directory \
-/home/ubuntu/actions-runner
-
-    rm "actions-runner-linux-$arch-$version.tar.gz"
-}
-
-function chown_home() {
-    /usr/bin/chown --recursive ubuntu:ubuntu /home/ubuntu/
 }
 
 proxy="test.proxy.internal:3128"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Allows users to define a URL to external script to run at the end of cloud-init script.

### Rationale

- To support flexible configuration of images via external scripts. (Security team use-case)

### Module Changes

- `openstack_builder.py` - passes `script-url` option to cloud-init template
- `cli.py` - parses the `script-url` option
- `template.sh.j2` - adds a function to execute external script.

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
