### PR TITLE
feat: external secret

### DIFF
--- a/src-docs/cli.md
+++ b/src-docs/cli.md
@@ -8,5 +8,6 @@ Main entrypoint for github-runner-image-builder cli application.
 **Global Variables**
 ---------------
 - **click**
+- **SECRET_PREFIX**
 
 

--- a/src-docs/config.md
+++ b/src-docs/config.md
@@ -94,7 +94,7 @@ The custom setup script configurations.
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(script_url: ParseResult | None, script_secrets: str | None) → None
+__init__(script_url: ParseResult | None, script_secrets: dict[str, str]) → None
 ```
 
 

--- a/src-docs/config.md
+++ b/src-docs/config.md
@@ -79,6 +79,36 @@ The ubuntu OS base image to build and deploy runners on.
 
 <a href="../src/github_runner_image_builder/config.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
+## <kbd>class</kbd> `ScriptConfig`
+The custom setup script configurations. 
+
+
+
+**Attributes:**
+ 
+ - <b>`script_url`</b>:  The external setup bash script URL. 
+ - <b>`script_secrets`</b>:  The space separated external secrets to load before running external             script_url. e.g. "SECRET_ONE=HELLO SECRET_TWO=WORLD" 
+
+<a href="../<string>"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `__init__`
+
+```python
+__init__(script_url: ParseResult | None, script_secrets: str | None) → None
+```
+
+
+
+
+
+
+
+
+
+---
+
+<a href="../src/github_runner_image_builder/config.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
 ## <kbd>class</kbd> `ImageConfig`
 The build image configuration values. 
 
@@ -91,7 +121,7 @@ The build image configuration values.
  - <b>`microk8s`</b>:  The MicroK8s snap channel to install. 
  - <b>`juju`</b>:  The Juju channel to install and bootstrap. 
  - <b>`runner_version`</b>:  The GitHub runner version to install on the VM. Defaults to latest. 
- - <b>`script_url`</b>:  The external setup bash script URL. 
+ - <b>`script_config`</b>:  The custom setup script configurations. 
  - <b>`name`</b>:  The image name to upload on OpenStack. 
 
 <a href="../<string>"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
@@ -105,7 +135,7 @@ __init__(
     microk8s: str,
     juju: str,
     runner_version: str,
-    script_url: ParseResult | None,
+    script_config: ScriptConfig,
     name: str
 ) → None
 ```

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -369,8 +369,8 @@ def _load_secrets() -> dict[str, str]:
     Returns:
         The secrets key value pairs.
     """
-    secrets: dict[str, str] = {}
-    for env in os.environ:
-        if env.startswith(SECRET_PREFIX):
-            secrets[env.removeprefix(SECRET_PREFIX)] = os.environ[env]
-    return secrets
+    return {
+        key.removeprefix(SECRET_PREFIX): value
+        for key, value in os.environ.items()
+        if key.startswith(SECRET_PREFIX)
+    }

--- a/src/github_runner_image_builder/cli.py
+++ b/src/github_runner_image_builder/cli.py
@@ -248,6 +248,12 @@ def _parse_url(
     "Installation is run as root within the cloud-init script after the bare image default setup.",
 )
 @click.option(
+    "--script-secrets",
+    default="",
+    help="The space separated external secrets to load before running external script_url. e.g. "
+    "SECRET_ONE=HELLO SECRET_TWO=WORLD",
+)
+@click.option(
     "--upload-clouds",
     default="",
     help="EXPERIMENTAL: Comma separated list of different clouds to use to upload the externally "
@@ -272,6 +278,7 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
     prefix: str,
     proxy: str,
     script_url: urllib.parse.ParseResult | None,
+    script_secrets: str | None,
     upload_clouds: str,
 ) -> None:
     """Build a cloud image using chroot and upload it to OpenStack.
@@ -294,6 +301,8 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
         prefix: The prefix to use for OpenStack resource names.
         proxy: Proxy to use for external build VMs.
         script_url: The external setup bash script URL.
+        script_secrets: The space separated external secrets to load before running external \
+            script_url. e.g. "SECRET_ONE=HELLO SECRET_TWO=WORLD"
         upload_clouds: The Openstack cloud to use to upload externally built image.
     """
     arch = arch if arch else config.get_supported_arch()
@@ -310,7 +319,10 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
                 microk8s=microk8s,
                 juju=juju,
                 runner_version=runner_version,
-                script_url=None,
+                script_config=config.ScriptConfig(
+                    script_url=None,
+                    script_secrets=None,
+                ),
                 name=image_name,
             ),
             keep_revisions=keep_revisions,
@@ -341,7 +353,10 @@ def run(  # pylint: disable=too-many-arguments, too-many-locals, too-many-positi
                 microk8s=microk8s,
                 juju=juju,
                 runner_version=runner_version,
-                script_url=script_url,
+                script_config=config.ScriptConfig(
+                    script_url=script_url,
+                    script_secrets=script_secrets,
+                ),
                 name=image_name,
             ),
             keep_revisions=keep_revisions,

--- a/src/github_runner_image_builder/config.py
+++ b/src/github_runner_image_builder/config.py
@@ -139,6 +139,20 @@ LOG_LEVELS = tuple(
 
 
 @dataclasses.dataclass
+class ScriptConfig:
+    """The custom setup script configurations.
+
+    Attributes:
+        script_url: The external setup bash script URL.
+        script_secrets: The space separated external secrets to load before running external \
+            script_url. e.g. "SECRET_ONE=HELLO SECRET_TWO=WORLD"
+    """
+
+    script_url: urllib.parse.ParseResult | None
+    script_secrets: str | None
+
+
+@dataclasses.dataclass
 class ImageConfig:
     """The build image configuration values.
 
@@ -148,7 +162,7 @@ class ImageConfig:
         microk8s: The MicroK8s snap channel to install.
         juju: The Juju channel to install and bootstrap.
         runner_version: The GitHub runner version to install on the VM. Defaults to latest.
-        script_url: The external setup bash script URL.
+        script_config: The custom setup script configurations.
         name: The image name to upload on OpenStack.
     """
 
@@ -157,5 +171,5 @@ class ImageConfig:
     microk8s: str
     juju: str
     runner_version: str
-    script_url: urllib.parse.ParseResult | None
+    script_config: ScriptConfig
     name: str

--- a/src/github_runner_image_builder/config.py
+++ b/src/github_runner_image_builder/config.py
@@ -149,7 +149,7 @@ class ScriptConfig:
     """
 
     script_url: urllib.parse.ParseResult | None
-    script_secrets: str | None
+    script_secrets: dict[str, str]
 
 
 @dataclasses.dataclass

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -496,7 +496,16 @@ def _generate_cloud_init_script(
         JUJU_CHANNEL=image_config.juju,
         RUNNER_VERSION=image_config.runner_version,
         RUNNER_ARCH=image_config.arch.value,
-        SCRIPT_URL=image_config.script_url.geturl() if image_config.script_url else "",
+        SCRIPT_URL=(
+            image_config.script_config.script_url.geturl()
+            if image_config.script_config.script_url
+            else ""
+        ),
+        SCRIPT_SECRETS=(
+            image_config.script_config.script_secrets
+            if image_config.script_config.script_secrets
+            else ""
+        ),
     )
 
 

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -502,7 +502,13 @@ def _generate_cloud_init_script(
             else ""
         ),
         SCRIPT_SECRETS=(
-            image_config.script_config.script_secrets
+            " ".join(
+                f"{secret_key}={secret_value}"
+                for (
+                    secret_key,
+                    secret_value,
+                ) in image_config.script_config.script_secrets.items()
+            )
             if image_config.script_config.script_secrets
             else ""
         ),

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -193,7 +193,10 @@ function execute_script() {
     fi
     # Write temp environment variables file, load and delete.
     TEMP_FILE=$(mktemp)
-    echo "$env_vars" > "$TEMP_FILE"
+    IFS=' ' read -r -a vars <<< "$env_vars"
+    for var in "${vars[@]}"; do
+        echo "$var" >> "$TEMP_FILE"
+    done
     # Source the temporary file and run the script
     set -a  # Automatically export all variables
     source "$TEMP_FILE"
@@ -217,6 +220,7 @@ github_runner_arch="{{ RUNNER_ARCH }}"
 microk8s_channel="{{ MICROK8S_CHANNEL }}"
 juju_channel="{{ JUJU_CHANNEL }}"
 script_url="{{ SCRIPT_URL }}"
+script_secrets="{{ SCRIPT_SECRETS }}"
 
 configure_proxy "$proxy"
 install_apt_packages "$apt_packages" "$hwe_version"
@@ -232,7 +236,7 @@ chown_home
 install_microk8s "$microk8s_channel" "$dockerhub_cache_url" "$dockerhub_cache_host" "$dockerhub_cache_port"
 install_juju "$juju_channel"
 configure_system_users
-execute_script "$script_url"
+execute_script "$script_url" "$script_secrets"
 
 # Make sure the disk is synced for snapshot
 sync

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -200,13 +200,13 @@ function execute_script() {
     # Source the temporary file and run the script
     set -a  # Automatically export all variables
     source "$TEMP_FILE"
+    rm "$TEMP_FILE"
     set +a  # Stop automatically exporting variables
 
     wget "$script_url" -O external.sh
     chmod +x external.sh
     ./external.sh
     rm external.sh
-    rm "$TEMP_FILE"
 }
 
 proxy="{{ PROXY_URL }}"

--- a/src/github_runner_image_builder/templates/cloud-init.sh.j2
+++ b/src/github_runner_image_builder/templates/cloud-init.sh.j2
@@ -186,14 +186,24 @@ function configure_system_users() {
 
 function execute_script() {
     local script_url="$1"
+    local env_vars="$2"
     if [[ -z "$script_url" ]]; then
         echo "Script URL not provided, skipping."
         return
     fi
+    # Write temp environment variables file, load and delete.
+    TEMP_FILE=$(mktemp)
+    echo "$env_vars" > "$TEMP_FILE"
+    # Source the temporary file and run the script
+    set -a  # Automatically export all variables
+    source "$TEMP_FILE"
+    set +a  # Stop automatically exporting variables
+
     wget "$script_url" -O external.sh
     chmod +x external.sh
     ./external.sh
     rm external.sh
+    rm "$TEMP_FILE"
 }
 
 proxy="{{ PROXY_URL }}"

--- a/tests/integration/commands.py
+++ b/tests/integration/commands.py
@@ -90,4 +90,14 @@ sudo microk8s stop && sudo microk8s start""",
         command="cat /home/ubuntu/test.txt | grep 'hello world'",
         external=True,
     ),
+    Commands(
+        name="test external script secrets (should exist)",
+        command='grep -q "SHOULD_EXIST" secret.txt',
+        external=True,
+    ),
+    Commands(
+        name="test external script secrets (should not exist)",
+        command='! grep -q "SHOULD_NOT_EXIST" secret.txt',
+        external=True,
+    ),
 )

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -106,10 +106,13 @@ def image_ids_fixture(
             runner_version="",
             name=f"{test_id}-image-builder-test",
             juju="3.1/stable",
-            script_url=urllib.parse.urlparse(
-                "https://raw.githubusercontent.com/canonical/github-runner-image-builder/"
-                "eb0ca315bf8c7aa732b811120cbabca4b8d16216/tests/integration/testdata/"
-                "test_script.sh"
+            script_config=config.ScriptConfig(
+                script_url=urllib.parse.urlparse(
+                    "https://raw.githubusercontent.com/canonical/github-runner-image-builder/"
+                    "eb0ca315bf8c7aa732b811120cbabca4b8d16216/tests/integration/testdata/"
+                    "test_script.sh"
+                ),
+                script_secrets="TEST_SECRET=SHOULD_EXIST TEST_NON_SECRET=SHOULD_NOT_EXIST",
             ),
         ),
         keep_revisions=1,

--- a/tests/integration/test_openstack_builder.py
+++ b/tests/integration/test_openstack_builder.py
@@ -112,7 +112,10 @@ def image_ids_fixture(
                     "eb0ca315bf8c7aa732b811120cbabca4b8d16216/tests/integration/testdata/"
                     "test_script.sh"
                 ),
-                script_secrets="TEST_SECRET=SHOULD_EXIST TEST_NON_SECRET=SHOULD_NOT_EXIST",
+                script_secrets={
+                    "TEST_SECRET": "SHOULD_EXIST",
+                    "TEST_NON_SECRET": "SHOULD_NOT_EXIST",
+                },
             ),
         ),
         keep_revisions=1,

--- a/tests/integration/testdata/test_script.sh
+++ b/tests/integration/testdata/test_script.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 sudo -H -u ubuntu bash -c 'echo "hello world" > /home/ubuntu/test.txt'
-sudo -HE -u ubuntu bash -c  echo "$TEST_SECRET" > /home/ubuntu/secret.txt'
+sudo -HE -u ubuntu bash -c  'echo "$TEST_SECRET" > /home/ubuntu/secret.txt'

--- a/tests/integration/testdata/test_script.sh
+++ b/tests/integration/testdata/test_script.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 sudo -H -u ubuntu bash -c 'echo "hello world" > /home/ubuntu/test.txt'
+sudo -HE -u ubuntu bash -c  echo "$TEST_SECRET" > /home/ubuntu/secret.txt'

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,6 +7,7 @@
 # pylint:disable=protected-access
 
 import itertools
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -247,3 +248,18 @@ def test_run(
     )
 
     assert result.exit_code == 0
+
+
+def test__load_secrets():
+    """
+    arrange: given secrets prefixed with IMAGE_BUILDER_SECRET_.
+    act: when _load_secrets is called.
+    assert: secrets are loaded correctly.
+    """
+    os.environ["IMAGE_BUILDER_SECRET_TEST_SECRET"] = (test_secret_value := "TEST_SECRET")
+    os.environ["IMAGE_BUILDER_SECRET_TEST_SECRET_SECONDARY"] = test_secret_value
+
+    assert cli._load_secrets() == {
+        "TEST_SECRET": test_secret_value,
+        "TEST_SECRET_SECONDARY": test_secret_value,
+    }

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -586,7 +586,7 @@ def test__generate_cloud_init_script():
                 name="test-image",
                 script_config=openstack_builder.config.ScriptConfig(
                     script_url=urllib.parse.urlparse("https://test-url.com/script.sh"),
-                    script_secrets="TEST_SECRET_ONE=HELLO TEST_SECRET_TWO=WORLD",
+                    script_secrets={"TEST_SECRET_ONE": "HELLO", "TEST_SECRET_TWO": "WORLD"},
                 ),
             ),
             proxy="test.proxy.internal:3128",

--- a/tests/unit/test_openstack_builder.py
+++ b/tests/unit/test_openstack_builder.py
@@ -801,13 +801,13 @@ function execute_script() {
     # Source the temporary file and run the script
     set -a  # Automatically export all variables
     source "$TEMP_FILE"
+    rm "$TEMP_FILE"
     set +a  # Stop automatically exporting variables
 
     wget "$script_url" -O external.sh
     chmod +x external.sh
     ./external.sh
     rm external.sh
-    rm "$TEMP_FILE"
 }
 
 proxy="test.proxy.internal:3128"


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Support secrets to be loaded as environment variables for external script run.

### Rationale

To allow flexibility in script runs where sensitive info could be required.
Use case: to run an installation of a software that requires installation key.

### Module Changes

- `cli.py`: exposes CLI option `script-secrets`
- `openstack_builder.py`: passes the option script-secrets to the cloud-init template.
- `cloud-init.sh.j2`: executes the script with secrets exported as environment variables.

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
