### PR TITLE
Decrease min ram requirements for openstack builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-image-builder"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/src/github_runner_image_builder/openstack_builder.py
+++ b/src/github_runner_image_builder/openstack_builder.py
@@ -56,7 +56,7 @@ SHARED_SECURITY_GROUP_NAME = "github-runner-image-builder-v1"
 CREATE_SERVER_TIMEOUT = 5 * 60  # seconds
 
 MIN_CPU = 2
-MIN_RAM = 8192  # M
+MIN_RAM = 1024  # M
 MIN_DISK = 20  # G
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Many of the images we build do not require 8GB of RAM, and can be build with just 1GB of RAM. That way, for example, our integration tests can execute with more limited resources.

### Rationale

<!-- The reason the change is needed -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library/Dependency Changes

<!-- Any changes to libraries -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation is generated using `src-docs`
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The application version in `pyproject.toml` is incremented

<!-- Explanation for any unchecked items above -->
